### PR TITLE
Reference query_files relative to JSON location

### DIFF
--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -51,7 +51,8 @@ func Run(_ *cobra.Command, args []string) {
 	}
 	for _, path := range args {
 		if st, err := processStagePath(path); err == nil {
-			mainStage.MergeWith(st)
+			stageWd := filepath.Dir(path)
+			mainStage.MergeWith(st, stageWd)
 			if defaultRunNameBuilder != nil {
 				if defaultRunNameBuilder.Len() > 0 {
 					defaultRunNameBuilder.WriteByte('_')
@@ -104,7 +105,7 @@ func processStagePath(path string) (st *stage.Stage, returnErr error) {
 			fullPath := filepath.Join(path, entry.Name())
 			newStage, err := processStagePath(fullPath)
 			if err == nil {
-				st.MergeWith(newStage)
+				st.MergeWith(newStage, filepath.Dir(fullPath))
 			}
 		}
 		return st, nil

--- a/stage/map.go
+++ b/stage/map.go
@@ -84,6 +84,7 @@ func ParseStage(stage *Stage, stages Map) (*Stage, error) {
 		if !filepath.IsAbs(queryFile) {
 			queryFile = filepath.Join(stage.BaseDir, queryFile)
 		}
+		
 		if _, err := os.Stat(queryFile); err != nil {
 			return nil, fmt.Errorf("%s links to an invalid query file %s: %w", stage.Id, queryFile, err)
 		}

--- a/stage/stage_utils.go
+++ b/stage/stage_utils.go
@@ -27,7 +27,7 @@ var DefaultNewClientFn = func() *presto.Client {
 	return client
 }
 
-func (s *Stage) MergeWith(other *Stage) *Stage {
+func (s *Stage) MergeWith(other *Stage, wd string) *Stage {
 	s.Id = other.Id
 	if other.Catalog != nil {
 		s.Catalog = other.Catalog
@@ -49,7 +49,14 @@ func (s *Stage) MergeWith(other *Stage) *Stage {
 		s.TimeZone = other.TimeZone
 	}
 	s.Queries = append(s.Queries, other.Queries...)
-	s.QueryFiles = append(s.QueryFiles, other.QueryFiles...)
+	for _, queryFile := range other.QueryFiles {
+		log.Info().Msg(fmt.Sprintf("%s||||%s", queryFile, wd))
+		absPath, err := filepath.Abs(filepath.Join(wd, queryFile))
+		if err != nil {
+			log.Fatal().Err(err).Msg(fmt.Sprintf("query file does not exist: %s", absPath))
+		}
+		s.QueryFiles = append(s.QueryFiles, absPath)
+	}
 	if s.ExpectedRowCounts == nil {
 		s.ExpectedRowCounts = make(map[string][]int)
 	}


### PR DESCRIPTION
Previously, the location at which query files would be referenced always depended upon the location of the final JSON file provided to the `run` command. This change sets the path of each query file equal to the location relative to the JSON which references it, allowing you to specify JSONs with query files from different directories.

Example:

```
benchmarks
└── tpch
    ├── queries
    ├── streams
    └─ tpch.json
└- file_with_session_property.json
```

Contents of `file_with_session_property.json`:

```json
{
    "session_params": {
        "optimizer_use_histograms": true
    }
}
```

Contents of `tpch.json`

```
{
  "description": "Sequentially run all 22 TPCH queries.",
  "query_files": [
    "queries/query_01.sql",
    "queries/query_02.sql",
     ....,
}
```

Before this change if you wanted to specify both of these JSON files and have the run complete successfully, you would always need to write `pbench run ./benchmarks/file_with_session_property.json ./benchmarks/tpch/tpch.json` rather than `pbench run ./benchmarks/tpch/tpch.json ./benchmarks/file_with_session_property.json`

Writing the arguments in opposite order would cause an error with a message specifying the query files are not found. This change should make the order independent. It also allows JSONs from different directories to specify additional query files

