### PR TITLE
add ";" to end of query

### DIFF
--- a/benchmarks/tpch/queries/query_03.sql
+++ b/benchmarks/tpch/queries/query_03.sql
@@ -21,4 +21,4 @@ GROUP BY
 ORDER BY
     revenue DESC,
     o.orderdate
-    LIMIT 10
+    LIMIT 10;


### PR DESCRIPTION
the file is missing a ";" 
pbench tool will skip this file unless we add ";" to the end of the query.