### PR TITLE
Enable list cache for hive catalog

### DIFF
--- a/clusters/2xlarge/catalog/hive-native.properties
+++ b/clusters/2xlarge/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/2xlarge/catalog/hive-native.properties
+++ b/clusters/2xlarge/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/2xlarge/catalog/hive.properties
+++ b/clusters/2xlarge/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/2xlarge/catalog/hive.properties
+++ b/clusters/2xlarge/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/large-ssd/catalog/hive-native.properties
+++ b/clusters/large-ssd/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/large-ssd/catalog/hive-native.properties
+++ b/clusters/large-ssd/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/large-ssd/catalog/hive.properties
+++ b/clusters/large-ssd/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/large-ssd/catalog/hive.properties
+++ b/clusters/large-ssd/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/large/catalog/hive-native.properties
+++ b/clusters/large/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/large/catalog/hive-native.properties
+++ b/clusters/large/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/large/catalog/hive.properties
+++ b/clusters/large/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/large/catalog/hive.properties
+++ b/clusters/large/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/medium-spill/catalog/hive-native.properties
+++ b/clusters/medium-spill/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/medium-spill/catalog/hive-native.properties
+++ b/clusters/medium-spill/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/medium-spill/catalog/hive.properties
+++ b/clusters/medium-spill/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/medium-spill/catalog/hive.properties
+++ b/clusters/medium-spill/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/medium-ssd/catalog/hive-native.properties
+++ b/clusters/medium-ssd/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/medium-ssd/catalog/hive-native.properties
+++ b/clusters/medium-ssd/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/medium-ssd/catalog/hive.properties
+++ b/clusters/medium-ssd/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/medium-ssd/catalog/hive.properties
+++ b/clusters/medium-ssd/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/medium/catalog/hive-native.properties
+++ b/clusters/medium/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/medium/catalog/hive-native.properties
+++ b/clusters/medium/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/medium/catalog/hive.properties
+++ b/clusters/medium/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/medium/catalog/hive.properties
+++ b/clusters/medium/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/small/catalog/hive-native.properties
+++ b/clusters/small/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/small/catalog/hive-native.properties
+++ b/clusters/small/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/small/catalog/hive.properties
+++ b/clusters/small/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/small/catalog/hive.properties
+++ b/clusters/small/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/templates/catalog/hive-native.properties
+++ b/clusters/templates/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/templates/catalog/hive-native.properties
+++ b/clusters/templates/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/templates/catalog/hive.properties
+++ b/clusters/templates/catalog/hive.properties
@@ -44,6 +44,9 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 
 {{ if .DataCacheEnabled -}}
 # alluxio data cache

--- a/clusters/templates/catalog/hive.properties
+++ b/clusters/templates/catalog/hive.properties
@@ -56,3 +56,8 @@ cache.alluxio.max-cache-size={{ .DataCacheSizeGb }}GB
 cache.alluxio.config-validation-enabled=true
 cache.base-directory=file:///data/presto-cache/alluxiodatacache/hive
 {{ end -}}
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xlarge-ssd/catalog/hive-native.properties
+++ b/clusters/xlarge-ssd/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xlarge-ssd/catalog/hive-native.properties
+++ b/clusters/xlarge-ssd/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/xlarge-ssd/catalog/hive.properties
+++ b/clusters/xlarge-ssd/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xlarge-ssd/catalog/hive.properties
+++ b/clusters/xlarge-ssd/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/xlarge/catalog/hive-native.properties
+++ b/clusters/xlarge/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xlarge/catalog/hive-native.properties
+++ b/clusters/xlarge/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/xlarge/catalog/hive.properties
+++ b/clusters/xlarge/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xlarge/catalog/hive.properties
+++ b/clusters/xlarge/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 

--- a/clusters/xsmall/catalog/hive-native.properties
+++ b/clusters/xsmall/catalog/hive-native.properties
@@ -48,3 +48,8 @@ hive.allow-rename-column=true
 # Constraints add/drop
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
+
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xsmall/catalog/hive-native.properties
+++ b/clusters/xsmall/catalog/hive-native.properties
@@ -45,3 +45,6 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true

--- a/clusters/xsmall/catalog/hive.properties
+++ b/clusters/xsmall/catalog/hive.properties
@@ -48,3 +48,7 @@ hive.allow-rename-column=true
 hive.allow-add-constraint=true
 hive.allow-drop-constraint=true
 
+# Directory List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache.max-retained-size=100MB
+hive.file-status-cache-tables=*

--- a/clusters/xsmall/catalog/hive.properties
+++ b/clusters/xsmall/catalog/hive.properties
@@ -44,4 +44,7 @@ hive.allow-rename-table=true
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+# Constraints add/drop
+hive.allow-add-constraint=true
+hive.allow-drop-constraint=true
 


### PR DESCRIPTION
Enable list cache for hive catalog.

This PR has 2 commits -
- Commit to enable directory list cache for hive catalogs
- Constraints add/drop information to keep it in sync with deployment