### PR TITLE
Update query_04.sql

### DIFF
--- a/benchmarks/tpch/queries/query_04.sql
+++ b/benchmarks/tpch/queries/query_04.sql
@@ -3,7 +3,7 @@ SELECT
     o.orderpriority,
     count(*) AS order_count
 FROM
-    "orders" o
+    orders o
 WHERE
     o.orderdate >= DATE '1993-07-01'
   AND o.orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH


### PR DESCRIPTION
Spark reports it cannot parse:


```
[PARSE_SYNTAX_ERROR] Syntax error at or near '"orders"'.(line 6, pos 4)

== SQL ==

SELECT
    o.orderpriority,
    count(*) AS order_count
FROM
    "orders" o
----^^^
```