### PR TITLE
Enabled connection pool for HTTP clients in native workers.

### DIFF
--- a/clusters/2xlarge/workers/config-native.properties
+++ b/clusters/2xlarge/workers/config-native.properties
@@ -13,7 +13,5 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=483
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 

--- a/clusters/large-ssd/workers/config-native.properties
+++ b/clusters/large-ssd/workers/config-native.properties
@@ -13,9 +13,7 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=241
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 
 # Ssd Cache on
 async-cache-ssd-gb=1800

--- a/clusters/large/workers/config-native.properties
+++ b/clusters/large/workers/config-native.properties
@@ -13,7 +13,5 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=241
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 

--- a/clusters/medium-spill/workers/config-native.properties
+++ b/clusters/medium-spill/workers/config-native.properties
@@ -13,9 +13,7 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=117
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 
 # spilling on
 memory-pool-init-capacity=536870912

--- a/clusters/medium-ssd/workers/config-native.properties
+++ b/clusters/medium-ssd/workers/config-native.properties
@@ -13,9 +13,7 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=117
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 
 # Ssd Cache on
 async-cache-ssd-gb=850

--- a/clusters/medium/workers/config-native.properties
+++ b/clusters/medium/workers/config-native.properties
@@ -13,7 +13,5 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=117
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 

--- a/clusters/small/workers/config-native.properties
+++ b/clusters/small/workers/config-native.properties
@@ -13,7 +13,5 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=55
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 

--- a/clusters/templates/workers/config-native.properties
+++ b/clusters/templates/workers/config-native.properties
@@ -13,9 +13,7 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb={{ sub .ContainerMemoryGb .GeneratorParameters.MemoryPushBackStartBelowLimitGb }}
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 
 {{ if .SpillEnabled -}}
 # spilling on

--- a/clusters/xlarge-ssd/workers/config-native.properties
+++ b/clusters/xlarge-ssd/workers/config-native.properties
@@ -13,9 +13,7 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=483
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 
 # Ssd Cache on
 async-cache-ssd-gb=1800

--- a/clusters/xlarge/workers/config-native.properties
+++ b/clusters/xlarge/workers/config-native.properties
@@ -13,7 +13,5 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=483
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 

--- a/clusters/xsmall/workers/config-native.properties
+++ b/clusters/xsmall/workers/config-native.properties
@@ -13,7 +13,5 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb=23
 system-mem-shrink-gb=20
 
-# To avoid the SEGV in HttpClient::createTransaction while the root cause is being fixed:
-# https://github.com/prestodb/presto/issues/22995
-exchange.http-client.enable-connection-pool=false
+exchange.http-client.enable-connection-pool=true
 


### PR DESCRIPTION
Changes the native-worker properties to enable HTTP client connection pooling that was disabled due to an issue that now has been resolved in the mean time.
