### PR TITLE
Update Presto native coordinator config

### DIFF
--- a/clusters/2xlarge/coordinator/config-native.properties
+++ b/clusters/2xlarge/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/large-ssd/coordinator/config-native.properties
+++ b/clusters/large-ssd/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/large/coordinator/config-native.properties
+++ b/clusters/large/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/medium-spill/coordinator/config-native.properties
+++ b/clusters/medium-spill/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/medium-ssd/coordinator/config-native.properties
+++ b/clusters/medium-ssd/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/medium/coordinator/config-native.properties
+++ b/clusters/medium/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/small/coordinator/config-native.properties
+++ b/clusters/small/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/templates/coordinator/config-native.properties
+++ b/clusters/templates/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/xlarge-ssd/coordinator/config-native.properties
+++ b/clusters/xlarge-ssd/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/xlarge/coordinator/config-native.properties
+++ b/clusters/xlarge/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10

--- a/clusters/xsmall/coordinator/config-native.properties
+++ b/clusters/xsmall/coordinator/config-native.properties
@@ -75,7 +75,6 @@ optimizer.optimize-hash-generation=false
 # Without this, decimal columns are treated as complex type while it should be scalar type. You will see errors like "scalar type has no children"
 # Another error we may observe is "Chunked http transferring encoding is not supported." https://github.ibm.com/lakehouse/velox/issues/74
 use-alternative-function-signatures=true
-experimental.table-writer-merge-operator-enabled=false
 inline-sql-functions=false
 offset-clause-enabled=true
 # We set this to true when comparing with DB2 https://github.ibm.com/lakehouse/velox/issues/10


### PR DESCRIPTION
Updates the Presto native coordinator config to remove the unsupported property `experimental.table-writer-merge-operator-enabled`. This property was removed in OSS Presto by [this commit](https://github.com/prestodb/presto/commit/b7501f982007919dffb6e44d02a228917baf44f5).