### PR TITLE
add query cancel sync for presto forward

### DIFF
--- a/cmd/forward/main.go
+++ b/cmd/forward/main.go
@@ -193,7 +193,10 @@ func checkAndCancelQuery(ctx context.Context, queryState *presto.QueryStateInfo)
 	if queryCacheEntries, ok := runningQueriesCacheMap[queryState.QueryId]; ok {
 		for _, q := range *queryCacheEntries {
 			if q.NextUri != "" {
-				q.Client.CancelQuery(ctx, q.NextUri)
+				_, _, cancelQueryErr := q.Client.CancelQuery(ctx, q.NextUri)
+				if cancelQueryErr != nil {
+					log.Error().Msgf("cancel query failed on target cluter: %s error: %s", q.NextUri, cancelQueryErr.Error())
+				}
 			}
 		}
 	}

--- a/presto/query_state.go
+++ b/presto/query_state.go
@@ -11,8 +11,8 @@ import (
 // https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfo.java
 // Unused fields are commented out for now.
 type QueryStateInfo struct {
-	QueryId string `json:"queryId"`
-	//QueryState string `json:"queryState"`
+	QueryId    string `json:"queryId"`
+	QueryState string `json:"queryState"`
 	//ResourceGroupId []string  `json:"resourceGroupId"`
 	//Query          string    `json:"query"`
 	//QueryTruncated bool      `json:"queryTruncated"`
@@ -41,6 +41,14 @@ type QueryStateInfo struct {
 	//	CompletedDrivers         int  `json:"completedDrivers"`
 	//} `json:"progress"`
 	//WarningCodes []interface{} `json:"warningCodes"`
+	ErrorCode QueryStateError `json:"errorCode"`
+}
+
+type QueryStateError struct {
+	Code      int    `json:"code"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Retriable bool   `json:"retriable"`
 }
 
 // GetQueryStatsOptions includes parameters in https://github.com/prestodb/presto/blob/a7af002182098ba5a61248edfcaaa66e5d50e489/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java#L89-L95


### PR DESCRIPTION
**Background:**  
Presto forward is a feature to monitor the workload in source Presto cluster and then clone the  workload to target clusters.

It's well working. There is one requirement which to syncronize the query cancel to target clusters. That means when the workload is canceled in source cluster, the target cluster should cancel the workload as well.

**Solution:**
1. Maintain a query cache, including the queryId in both of source and target clusters, the nextUri for canceling the query. When a query is triggered in target clusters, the cache is updated.  While after the query execution completion,  remove the query in the cache.
2. In next sync, check if there is any query is canceled in source cluster. If it does, and then to match in the cache.  If it's found in cache, means it's still running. And then call api to cancel the query.