### PR TITLE
Remove hive_statistics_merge_strategy from iceberg benchmarks

### DIFF
--- a/benchmarks/tpc-ds/sf10k_ice.json
+++ b/benchmarks/tpc-ds/sf10k_ice.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpcds_sf10000_parquet_iceberg",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpc-ds/sf10k_ice_par.json
+++ b/benchmarks/tpc-ds/sf10k_ice_par.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpcds_sf10000_parquet_varchar_iceberg_part",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpc-ds/sf1k_ice.json
+++ b/benchmarks/tpc-ds/sf1k_ice.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpcds_sf1000_parquet_iceberg",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpc-ds/sf1k_ice_par.json
+++ b/benchmarks/tpc-ds/sf1k_ice_par.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpcds_sf1000_parquet_varchar_iceberg_part",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpc-ds/sf1k_ice_uncompressed.json
+++ b/benchmarks/tpc-ds/sf1k_ice_uncompressed.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpcds_sf1000_parquet_uncompressed_iceberg",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpc-ds/sf30k_ice.json
+++ b/benchmarks/tpc-ds/sf30k_ice.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpcds_sf30000_parquet_iceberg",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpch/sf1k_ice.json
+++ b/benchmarks/tpch/sf1k_ice.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpch_sf1000_parquet_iceberg",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }

--- a/benchmarks/tpch/sf1k_ice_par.json
+++ b/benchmarks/tpch/sf1k_ice_par.json
@@ -3,7 +3,6 @@
   "catalog": "iceberg",
   "schema": "tpch_sf1000_parquet_partitioned_iceberg",
   "session_params": {
-    "iceberg.hive_statistics_merge_strategy": "NUMBER_OF_DISTINCT_VALUES,TOTAL_SIZE_IN_BYTES",
     "optimizer_use_histograms": true
   }
 }


### PR DESCRIPTION
This is no longer required since Presto 289. The iceberg connector natively supports storing data size and NDVs without use of the HMS, even when the HMS is configured.

In fact, since HMS response caching was disabled, these parameters negatively impact Iceberg query analysis performance. It is best to leave the defaults.