### PR TITLE
Improved organization of pbench output directory and detection of duplicate stages in nested stages

### DIFF
--- a/stage/run_recorder.go
+++ b/stage/run_recorder.go
@@ -42,5 +42,5 @@ func (f *FileBasedRunRecorder) RecordQuery(_ context.Context, _ *Stage, result *
 }
 
 func (f *FileBasedRunRecorder) RecordRun(_ context.Context, s *Stage, _ []*QueryResult) {
-	_ = os.WriteFile(filepath.Join(s.States.OutputPath, s.Id+"_summary.csv"), []byte(f.summaryBuilder.String()), 0644)
+	_ = os.WriteFile(filepath.Join(s.States.OutputPath, s.States.RunName+"_summary.csv"), []byte(f.summaryBuilder.String()), 0644)
 }

--- a/stage/stage_utils.go
+++ b/stage/stage_utils.go
@@ -290,7 +290,7 @@ func (s *Stage) saveQueryJsonFile(result *QueryResult) {
 		querySourceStr := s.querySourceString(result)
 		{
 			queryJsonFile, err := os.OpenFile(
-				filepath.Join(s.States.OutputPath, querySourceStr)+".json",
+				filepath.Join(s.OutputPath, querySourceStr)+".json",
 				utils.OpenNewFileFlags, 0644)
 			checkErr(err)
 			if err == nil {
@@ -302,7 +302,7 @@ func (s *Stage) saveQueryJsonFile(result *QueryResult) {
 		}
 		if result.QueryError != nil {
 			queryErrorFile, err := os.OpenFile(
-				filepath.Join(s.States.OutputPath, querySourceStr)+".error.json",
+				filepath.Join(s.OutputPath, querySourceStr)+".error.json",
 				utils.OpenNewFileFlags, 0644)
 			checkErr(err)
 			if err == nil {
@@ -332,7 +332,7 @@ func (s *Stage) saveColumnMetadataFile(qr *presto.QueryResults, result *QueryRes
 		}
 	}()
 	columnMetadataFile, ioErr := os.OpenFile(
-		filepath.Join(s.States.OutputPath, querySourceStr)+".cols.json",
+		filepath.Join(s.OutputPath, querySourceStr)+".cols.json",
 		utils.OpenNewFileFlags, 0644)
 	if ioErr != nil {
 		return ioErr
@@ -371,4 +371,20 @@ func (s *Stage) querySourceString(result *QueryResult) (sourceStr string) {
 		sourceStr += strconv.Itoa(result.Query.SequenceNo)
 	}
 	return
+}
+
+func (s *Stage) createNextStagesOutputDirectories() {
+	// Create parent stage id file path
+	utils.PrepareOutputDirectory(s.OutputPath)
+	for _, nextStage := range s.NextStages {
+		// Construct the output directory path
+		stageOutputPath := filepath.Join(s.OutputPath, nextStage.Id)
+		nextStage.OutputPath = stageOutputPath
+		
+		// Create the directory
+		utils.PrepareOutputDirectory(stageOutputPath)
+
+		// Recursively call the function on the child stage
+		nextStage.createNextStagesOutputDirectories()
+	}
 }


### PR DESCRIPTION
Improved organization of pbench output directory to navigate easier for streams runs.

Example 3 streams run:

pbench command ran:
```
../pbench_mcao run -n testing_output_dir_change_%t -s http://127.0.0.1:8081 -o /root/oss_pbench/pbench/benchmarks/benchmark_base native_oss.json save_output.json save_json.json
 tpch/sf1_tpchstandard.json tpch/3streams.json > pbench_output2.txt 2>&
1
```

3streams.json:
```
{
    "description": "Launch 3 clients, each running from tpch.",
    "next": [
      "tpch_stream1.json",
      "tpch_stream2.json",
      "tpch_stream3.json"
    ],
    "query_files": [
      "queries_tpchstandard/query_01.sql"
    ]
}


```

tpch_stream1.json:
```
{
    "description": "Sequentially run 3 TPCH queries.",
    "next": [
      "tpch_stream1_child.json"
    ],
    "query_files": [
      "queries_tpchstandard/query_01.sql"
    ],
    "expected_row_counts": {
      "tpch_sf1000_": [
        4,
        100,
        10
      ]
    }
}


```

tpch_stream2.json, tpch_stream3.json:
```
{
    "description": "Sequentially run 3 TPCH queries.",
    "query_files": [
      "queries_tpchstandard/query_01.sql"
    ],
    "expected_row_counts": {
      "tpch_sf1000_": [
        4,
        100,
        10
      ]
    }
}


```

tpch_stream1_child.json:
```
{
    "description": "Sequentially run 3 TPCH queries.",
    "query_files": [
      "queries_tpchstandard/query_01.sql"
    ],
    "expected_row_counts": {
      "tpch_sf1000_": [
        4,
        100,
        10
      ]
    }
}

```


<img width="672" height="446" alt="image" src="https://github.com/user-attachments/assets/4ed10faa-a1d7-4204-b0d1-315490b72bda" />
