### PR TITLE
fix: bump Go toolchain to 1.26.4 to patch stdlib vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Run go vet
         run: go vet ./...
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Build
         run: go build ./...
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Build pbench
         run: go build -o ./bin/pbench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Build and package
         run: make tar

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module pbench
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4


### PR DESCRIPTION
## What

Bumps the Go toolchain from **1.26.2 → 1.26.4**:
- `go` directive in `go.mod`
- `setup-go` version pins in `.github/workflows/ci.yml` (6×) and `release.yml` (1×)

## Why

`govulncheck ./...` flagged **6 standard-library vulnerabilities**, all fixed across go1.26.3 / go1.26.4:

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-5039 | net/textproto | 1.26.4 |
| GO-2026-5037 | crypto/x509 | 1.26.4 |
| GO-2026-4986 | net/mail | 1.26.3 |
| GO-2026-4977 | net/mail | 1.26.3 |
| GO-2026-4971 | net | 1.26.3 |
| GO-2026-4918 | net/http | 1.26.3 |

These are all stdlib issues — no first-party code changes were needed.

## Verification

- `go build ./...`, `go vet ./...` clean
- Pre-commit hook (full test suite + coverage) passes
- `govulncheck ./...` → **"Your code is affected by 0 vulnerabilities."** (was 6)