### PR TITLE
perf: add -snapshots in pbench run for collecting time series metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Run go vet
         run: go vet ./...
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Build
         run: go build ./...
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Build pbench
         run: go build -o ./bin/pbench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Build and package
         run: make tar

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,4 +30,12 @@ func init() {
 	runCmd.Flags().StringVar(&run.InfluxCfgPath, "influx", "", "InfluxDB connection config for run recorder (optional)")
 	runCmd.Flags().StringVar(&run.MySQLCfgPath, "mysql", "", "MySQL connection config for run recorder (optional)")
 	runCmd.Flags().StringVar(&run.PulumiCfgPath, "pulumi", "", "(only works when a MySQL run recorder is specified) Pulumi API config for storing deployment details with MySQL (optional)")
+	runCmd.Flags().BoolVar(&run.Snapshots, "snapshots", false,
+		"Periodically save /v1/query snapshots while queries run (DIAGNOSTIC MODE: adds coordinator load, not for timed baseline runs; default false)")
+	runCmd.Flags().DurationVar(&run.SnapshotInterval, "snapshot-interval", 30*time.Second,
+		"Polling interval for query json snapshots when --snapshots is on (floor 5s)")
+	runCmd.Flags().IntVar(&run.SnapshotMax, "snapshot-max", 20,
+		"Maximum snapshots retained per query (0 = unlimited; must be set explicitly)")
+	runCmd.Flags().DurationVar(&run.SnapshotFetchTimeout, "snapshot-fetch-timeout", 0,
+		"Per-fetch timeout for query json snapshots (default: same as --snapshot-interval)")
 }

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -24,6 +24,14 @@ var (
 	InfluxCfgPath string
 	MySQLCfgPath  string
 	PulumiCfgPath string
+	// Snapshots and friends are the run-wide defaults for periodic query JSON snapshot
+	// collection (diagnostic mode; see stage/json_snapshot.go). Individual stages can
+	// override them via save_json_snapshots / json_snapshot_interval / json_snapshot_max /
+	// json_snapshot_fetch_timeout.
+	Snapshots            bool
+	SnapshotInterval     time.Duration
+	SnapshotMax          int
+	SnapshotFetchTimeout time.Duration
 )
 
 func Run(_ *cobra.Command, args []string) {
@@ -35,17 +43,7 @@ func Run(_ *cobra.Command, args []string) {
 	utils.ExpandHomeDirectory(&InfluxCfgPath)
 	utils.ExpandHomeDirectory(&MySQLCfgPath)
 	utils.ExpandHomeDirectory(&PulumiCfgPath)
-	mainStage := &stage.Stage{
-		States: &stage.SharedStageStates{
-			RunName:      Name,
-			Comment:      Comment,
-			RandSeed:     RandSeed,
-			RandSkip:     RandSkip,
-			ServerFQDN:   parsedServerUrl.Host,
-			RunStartTime: time.Now(),
-			OutputPath:   OutputPath,
-		},
-	}
+	mainStage := &stage.Stage{States: newSharedStageStates(parsedServerUrl)}
 
 	var defaultRunNameBuilder *strings.Builder
 	if mainStage.States.RunName == "" {
@@ -84,6 +82,27 @@ func Run(_ *cobra.Command, args []string) {
 	mainStage.States.RegisterRunRecorder(mySQLRunRecorder)
 	mainStage.States.RegisterRunRecorder(stage.NewPulumiMySQLRunRecorder(PulumiCfgPath, mySQLRunRecorder))
 	os.Exit(mainStage.Run(context.Background()))
+}
+
+// newSharedStageStates builds the SharedStageStates populated from the run-level CLI flag
+// vars, including the four --snapshots/--snapshot-interval/--snapshot-max/
+// --snapshot-fetch-timeout vars (M2). Extracted out of Run() - which calls os.Exit() and so
+// cannot be safely invoked from a test - specifically so this flag-to-SharedStageStates
+// wiring can be asserted directly; see main_test.go.
+func newSharedStageStates(parsedServerUrl *url.URL) *stage.SharedStageStates {
+	return &stage.SharedStageStates{
+		RunName:              Name,
+		Comment:              Comment,
+		RandSeed:             RandSeed,
+		RandSkip:             RandSkip,
+		ServerFQDN:           parsedServerUrl.Host,
+		RunStartTime:         time.Now(),
+		OutputPath:           OutputPath,
+		SnapshotsEnabled:     Snapshots,
+		SnapshotInterval:     SnapshotInterval,
+		SnapshotMax:          SnapshotMax,
+		SnapshotFetchTimeout: SnapshotFetchTimeout,
+	}
 }
 
 func processStagePath(path string) (st *stage.Stage, returnErr error) {

--- a/cmd/run/main_test.go
+++ b/cmd/run/main_test.go
@@ -1,0 +1,95 @@
+package run
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// M2: asserts the run-level CLI flag vars (Snapshots, SnapshotInterval, SnapshotMax,
+// SnapshotFetchTimeout - populated by cmd/run.go's flag registration) are correctly copied
+// into SharedStageStates by newSharedStageStates(), for both the documented defaults
+// (30s / 20 / 0=use-interval) and explicit overrides. Run() itself calls os.Exit() at the
+// end and so cannot be invoked directly from a test; newSharedStageStates() was extracted
+// specifically to make this wiring testable in isolation (see main.go).
+func TestNewSharedStageStates_SnapshotFlagDefaults(t *testing.T) {
+	restoreSnapshotVars(t)
+	// Mirrors the defaults cmd/run.go registers for these flags.
+	Snapshots = false
+	SnapshotInterval = 30 * time.Second
+	SnapshotMax = 20
+	SnapshotFetchTimeout = 0
+
+	states := newSharedStageStates(mustParseURL(t, "http://localhost:8080"))
+
+	assert.False(t, states.SnapshotsEnabled)
+	assert.Equal(t, 30*time.Second, states.SnapshotInterval)
+	assert.Equal(t, 20, states.SnapshotMax)
+	assert.Equal(t, time.Duration(0), states.SnapshotFetchTimeout, "0 means \"use the interval\", resolved later in stage.resolveSnapshotSettings")
+}
+
+func TestNewSharedStageStates_SnapshotFlagOverrides(t *testing.T) {
+	restoreSnapshotVars(t)
+	Snapshots = true
+	SnapshotInterval = 45 * time.Second
+	SnapshotMax = 0 // explicit unlimited
+	SnapshotFetchTimeout = 90 * time.Second
+
+	states := newSharedStageStates(mustParseURL(t, "http://localhost:8080"))
+
+	assert.True(t, states.SnapshotsEnabled)
+	assert.Equal(t, 45*time.Second, states.SnapshotInterval)
+	assert.Equal(t, 0, states.SnapshotMax)
+	assert.Equal(t, 90*time.Second, states.SnapshotFetchTimeout)
+}
+
+// TestNewSharedStageStates_OtherFieldsUnaffected is a light sanity check that the
+// pre-existing (non-snapshot) wiring survived the refactor that extracted
+// newSharedStageStates() out of Run().
+func TestNewSharedStageStates_OtherFieldsUnaffected(t *testing.T) {
+	restoreSnapshotVars(t)
+	origName, origComment, origSeed, origSkip, origOutput := Name, Comment, RandSeed, RandSkip, OutputPath
+	t.Cleanup(func() {
+		Name, Comment, RandSeed, RandSkip, OutputPath = origName, origComment, origSeed, origSkip, origOutput
+	})
+	Name = "my_run"
+	Comment = "a comment"
+	RandSeed = 42
+	RandSkip = 3
+	OutputPath = "/tmp/somewhere"
+
+	states := newSharedStageStates(mustParseURL(t, "http://coordinator.example.com:8889"))
+
+	assert.Equal(t, "my_run", states.RunName)
+	assert.Equal(t, "a comment", states.Comment)
+	assert.Equal(t, int64(42), states.RandSeed)
+	assert.Equal(t, 3, states.RandSkip)
+	assert.Equal(t, "/tmp/somewhere", states.OutputPath)
+	assert.Equal(t, "coordinator.example.com:8889", states.ServerFQDN)
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+// restoreSnapshotVars snapshots and restores the four package-level snapshot flag vars so
+// tests don't leak mutations into each other.
+func restoreSnapshotVars(t *testing.T) {
+	t.Helper()
+	origSnapshots := Snapshots
+	origInterval := SnapshotInterval
+	origMax := SnapshotMax
+	origTimeout := SnapshotFetchTimeout
+	t.Cleanup(func() {
+		Snapshots = origSnapshots
+		SnapshotInterval = origInterval
+		SnapshotMax = origMax
+		SnapshotFetchTimeout = origTimeout
+	})
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"pbench/cmd/run"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// M2: verifies the four snapshot flags are actually registered on runCmd (cmd/run.go's
+// init()) with the documented defaults (design.md §4.1: --snapshots default false,
+// --snapshot-interval default 30s, --snapshot-max default 20, --snapshot-fetch-timeout
+// default 0 = "use the interval"), and that setting them updates the run package vars they
+// are bound to. This is the flag-registration half of the wiring; cmd/run/main_test.go
+// covers the SharedStageStates-construction half (newSharedStageStates()).
+func TestRunCmdSnapshotFlags_RegisteredWithDocumentedDefaults(t *testing.T) {
+	flags := runCmd.Flags()
+
+	snapshotsFlag := flags.Lookup("snapshots")
+	require.NotNil(t, snapshotsFlag, "--snapshots must be registered on `pbench run`")
+	assert.Equal(t, "false", snapshotsFlag.DefValue)
+
+	intervalFlag := flags.Lookup("snapshot-interval")
+	require.NotNil(t, intervalFlag, "--snapshot-interval must be registered on `pbench run`")
+	assert.Equal(t, "30s", intervalFlag.DefValue)
+
+	maxFlag := flags.Lookup("snapshot-max")
+	require.NotNil(t, maxFlag, "--snapshot-max must be registered on `pbench run`")
+	assert.Equal(t, "20", maxFlag.DefValue)
+
+	fetchTimeoutFlag := flags.Lookup("snapshot-fetch-timeout")
+	require.NotNil(t, fetchTimeoutFlag, "--snapshot-fetch-timeout must be registered on `pbench run`")
+	assert.Equal(t, "0s", fetchTimeoutFlag.DefValue, `0 means "use the polling interval", resolved later in stage.resolveSnapshotSettings`)
+}
+
+// TestRunCmdSnapshotFlags_ParsingUpdatesBoundVars proves the flags are bound to the exact
+// run package vars that newSharedStageStates() reads from (rather than merely registered),
+// by parsing a flag set and checking the bound vars afterwards.
+func TestRunCmdSnapshotFlags_ParsingUpdatesBoundVars(t *testing.T) {
+	restoreCmdSnapshotVars(t)
+
+	err := runCmd.Flags().Parse([]string{
+		"--snapshots",
+		"--snapshot-interval=45s",
+		"--snapshot-max=7",
+		"--snapshot-fetch-timeout=90s",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, run.Snapshots)
+	assert.Equal(t, 45*time.Second, run.SnapshotInterval)
+	assert.Equal(t, 7, run.SnapshotMax)
+	assert.Equal(t, 90*time.Second, run.SnapshotFetchTimeout)
+}
+
+// restoreCmdSnapshotVars snapshots and restores the run package's snapshot vars (and resets
+// the flags to their defaults) so this test doesn't leak state into others.
+func restoreCmdSnapshotVars(t *testing.T) {
+	t.Helper()
+	origSnapshots := run.Snapshots
+	origInterval := run.SnapshotInterval
+	origMax := run.SnapshotMax
+	origTimeout := run.SnapshotFetchTimeout
+	t.Cleanup(func() {
+		run.Snapshots = origSnapshots
+		run.SnapshotInterval = origInterval
+		run.SnapshotMax = origMax
+		run.SnapshotFetchTimeout = origTimeout
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module pbench
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/stage/json_snapshot.go
+++ b/stage/json_snapshot.go
@@ -1,0 +1,313 @@
+package stage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"pbench/log"
+	"pbench/utils"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultSnapshotInterval is the built-in default snapshot polling interval, used
+	// when neither a per-stage json_snapshot_interval override nor the run-wide
+	// --snapshot-interval CLI flag resolves to a usable (positive) value.
+	DefaultSnapshotInterval = 30 * time.Second
+	// DefaultSnapshotMax is the built-in default snapshot retention cap per query
+	// (~10 minutes of coverage at the default 30s interval). 0 means unlimited.
+	DefaultSnapshotMax = 20
+	// MinSnapshotInterval is the floor below which a configured snapshot interval is
+	// clamped (with a warning), to protect the coordinator from excessive polling.
+	MinSnapshotInterval = 5 * time.Second
+	// maxSnapshotBackoffTicks caps the exponential backoff applied after consecutive
+	// snapshot fetch failures (FP-6): skip 1, 2, 4, 8, 8, 8, ... ticks.
+	maxSnapshotBackoffTicks = 8
+)
+
+// resolveSnapshotSettings resolves the effective, fully-materialized snapshot settings
+// for this stage into the private snapshotsEnabled/snapshotInterval/snapshotMax/
+// snapshotFetchTimeout fields. Called once per stage from setDefaults(), per the fixed
+// precedence: per-stage JSON value > CLI flag (run-wide default via SharedStageStates) >
+// built-in default (design.md §4.1).
+func (s *Stage) resolveSnapshotSettings() {
+	if s.SaveJsonSnapshots != nil {
+		s.snapshotsEnabled = *s.SaveJsonSnapshots
+	} else {
+		s.snapshotsEnabled = s.States.SnapshotsEnabled
+	}
+
+	s.snapshotInterval = s.States.SnapshotInterval
+	if s.snapshotInterval <= 0 {
+		s.snapshotInterval = DefaultSnapshotInterval
+	}
+	if s.JsonSnapshotInterval != nil {
+		if d, err := time.ParseDuration(*s.JsonSnapshotInterval); err != nil {
+			log.Error().Err(err).EmbedObject(s).Str("json_snapshot_interval", *s.JsonSnapshotInterval).
+				Msg("failed to parse json_snapshot_interval; disabling json snapshots for this stage")
+			s.snapshotsEnabled = false
+		} else {
+			s.snapshotInterval = d
+		}
+	}
+	if s.snapshotInterval < MinSnapshotInterval {
+		log.Warn().EmbedObject(s).Dur("requested_interval", s.snapshotInterval).
+			Dur("floor", MinSnapshotInterval).Msg("json snapshot interval below floor; clamping")
+		s.snapshotInterval = MinSnapshotInterval
+	}
+
+	if s.JsonSnapshotMax != nil {
+		s.snapshotMax = *s.JsonSnapshotMax
+	} else {
+		s.snapshotMax = s.States.SnapshotMax
+	}
+	if s.snapshotMax < 0 {
+		// Should already be rejected by struct validation (validate:"omitempty,gte=0")
+		// when parsed from JSON, but guard against direct/programmatic construction too.
+		s.snapshotMax = DefaultSnapshotMax
+	}
+
+	s.snapshotFetchTimeout = s.States.SnapshotFetchTimeout
+	if s.JsonSnapshotFetchTimeout != nil {
+		if d, err := time.ParseDuration(*s.JsonSnapshotFetchTimeout); err != nil {
+			log.Error().Err(err).EmbedObject(s).Str("json_snapshot_fetch_timeout", *s.JsonSnapshotFetchTimeout).
+				Msg("failed to parse json_snapshot_fetch_timeout; falling back to the polling interval")
+			s.snapshotFetchTimeout = 0
+		} else {
+			s.snapshotFetchTimeout = d
+		}
+	}
+	if s.snapshotFetchTimeout <= 0 {
+		// Default: the (already-resolved) polling interval (FP-7).
+		s.snapshotFetchTimeout = s.snapshotInterval
+	}
+}
+
+// jsonSnapshotPoller periodically fetches GET /v1/query/{queryId} while a query runs and
+// saves each raw response, verbatim, to a snapshot file. See design.md §4.2. A single
+// poller goroutine is created per polled query.
+type jsonSnapshotPoller struct {
+	stage        *Stage
+	queryId      string
+	dir          string // <OutputPath>/<querySourceStr>.snapshots
+	interval     time.Duration
+	fetchTimeout time.Duration // default == interval
+	max          int           // <= 0 means unlimited
+
+	// cancel cancels the context passed to run()/captureOnce(). stop() calls this instead
+	// of signalling a separate "stop" channel: deriving every fetch's context from the same
+	// cancelable context means stop() deterministically aborts a fetch that is already in
+	// flight (not just future ones) - see stop() and captureOnce() for the hard guarantee
+	// this gives (review finding M1). stopOnce makes calling it more than once, or calling
+	// it concurrently with run() exiting on its own (e.g. via the caller's ctx), safe.
+	cancel   context.CancelFunc
+	stopOnce sync.Once
+
+	seq        int
+	saved      []string // retained snapshot file paths, in capture order, for FP-5 retention
+	failStreak int      // consecutive failures, drives exponential backoff (FP-6)
+	dirReady   bool     // true once the .snapshots dir has been created; single-goroutine field
+}
+
+// startJsonSnapshotPoller starts a background poller for the query identified by
+// result.QueryId, registering its goroutine on s.States.wgExitMainStage exactly like the
+// async writer in saveQueryJsonFile. It returns nil when snapshotting is disabled for this
+// stage or the query id is not yet known (e.g. the query failed to submit); stop() on a
+// nil *jsonSnapshotPoller is a safe no-op, so callers do not need to nil-check first.
+func (s *Stage) startJsonSnapshotPoller(ctx context.Context, result *QueryResult) *jsonSnapshotPoller {
+	if !s.snapshotsEnabled || result.QueryId == "" {
+		return nil
+	}
+	querySourceStr := s.querySourceString(result)
+	// pollCtx is derived from the caller's ctx and is also the context every fetch's
+	// context.WithTimeout is built from; canceling it (via stop(), or transitively via the
+	// caller's ctx being canceled) aborts an in-flight fetch immediately rather than merely
+	// preventing the *next* one - see captureOnce().
+	pollCtx, cancel := context.WithCancel(ctx)
+	p := &jsonSnapshotPoller{
+		stage:        s,
+		queryId:      result.QueryId,
+		dir:          filepath.Join(s.States.OutputPath, querySourceStr+".snapshots"),
+		interval:     s.snapshotInterval,
+		fetchTimeout: s.snapshotFetchTimeout,
+		max:          s.snapshotMax,
+		cancel:       cancel,
+	}
+	s.States.wgExitMainStage.Add(1)
+	go p.run(pollCtx)
+	return p
+}
+
+// run is the poller goroutine body. It exits when ctx is canceled - either because stop()
+// was called (normal completion) or because the caller's ctx was canceled (abort); the
+// terminal save in saveQueryJsonFile still runs on context.Background() and captures final
+// state independently either way.
+func (p *jsonSnapshotPoller) run(ctx context.Context) {
+	defer p.stage.States.wgExitMainStage.Done()
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	// skipTicks implements the exponential backoff window from FP-6: while positive, ticks
+	// are consumed without triggering a fetch.
+	skipTicks := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Because this loop is single-threaded and captureOnce is synchronous, a slow
+			// fetch naturally causes any tick(s) that occur while it is running to be
+			// coalesced/dropped by time.Ticker - there is no overlap and no backpressure
+			// queue is needed (FP-3).
+			//
+			// No extra "is ctx already done?" pre-check is needed here (an earlier version
+			// of this fix had one): even if select's pseudo-random choice between ready
+			// cases picks this branch despite ctx already being canceled (e.g. stop() raced
+			// a tick that was already buffered while a prior, slow captureOnce was in
+			// flight), captureOnce's own context is derived from - and canceled together
+			// with - ctx (see captureOnce/startJsonSnapshotPoller), so it fails
+			// deterministically instead of writing a frame. The ctx.Err() check right below
+			// turns that into a clean exit rather than a logged failure/backoff. This is the
+			// hard guarantee M1 asks for: it does not depend on winning any select race.
+			if skipTicks > 0 {
+				skipTicks--
+				continue
+			}
+			if err := p.captureOnce(ctx); err != nil {
+				if ctx.Err() != nil {
+					// stop() (or the caller's ctx) was canceled during, or immediately
+					// before, this capture; the fetch's own context is derived from ctx
+					// (see captureOnce), so it aborted deterministically instead of writing
+					// a frame (M1's hard guarantee). This is a shutdown, not a fetch
+					// failure: exit without logging a warning or applying backoff.
+					return
+				}
+				p.failStreak++
+				log.Warn().Err(err).Str("query_id", p.queryId).Int("seq", p.seq).
+					Int("fail_streak", p.failStreak).Msg("json snapshot fetch failed")
+				skipTicks = snapshotBackoffTicks(p.failStreak)
+			} else {
+				p.failStreak = 0
+			}
+		}
+	}
+}
+
+// snapshotBackoffTicks returns the number of ticks to skip after failStreak consecutive
+// failures: 1, 2, 4, 8, 8, 8, ... (never disables the poller permanently, FP-6).
+func snapshotBackoffTicks(failStreak int) int {
+	if failStreak <= 0 {
+		return 0
+	}
+	if failStreak > 4 {
+		return maxSnapshotBackoffTicks
+	}
+	return 1 << (failStreak - 1)
+}
+
+// captureOnce fetches the query's current /v1/query/{queryId} JSON and streams it,
+// verbatim, to the next snapshot file. On success it advances seq, records the saved path
+// for retention accounting, and applies retention (FP-5). On any error - including ctx
+// being canceled mid-fetch (M1: stop() cancels ctx, so an in-flight fetch is aborted
+// deterministically rather than left to complete) - the partially written file is removed
+// and the error is returned for the caller to log/back off on (unless the cause was
+// cancellation, handled by the caller without backoff).
+func (p *jsonSnapshotPoller) captureOnce(ctx context.Context) error {
+	// The .snapshots directory is created lazily, on the first attempted capture, rather
+	// than eagerly when the poller starts (N1): a query that drains before its first tick
+	// fires (or one where snapshotting never ticks at all) leaves no empty directory behind.
+	if !p.dirReady {
+		if err := os.MkdirAll(p.dir, 0755); err != nil {
+			return fmt.Errorf("create snapshot dir: %w", err)
+		}
+		p.dirReady = true
+	}
+	nextSeq := p.seq + 1
+	// Zero-padded to 6 digits (N3): 4 digits would break lexical/glob ordering past 9999
+	// frames. Phase-2 frame discovery parses the numeric seq out of the name rather than
+	// relying on lexical order, so widening the padding does not affect that parsing, and
+	// the snapshot_<seq>_<epochMillis>.json shape is unchanged.
+	path := filepath.Join(p.dir, fmt.Sprintf("snapshot_%06d_%d.json", nextSeq, time.Now().UnixMilli()))
+	file, err := os.OpenFile(path, utils.OpenNewFileFlags, 0644)
+	if err != nil {
+		return err
+	}
+	qCtx, qCancel := context.WithTimeout(ctx, p.fetchTimeout)
+	// Raw stream to disk, identical mechanism to saveQueryJsonFile: the file carries
+	// Presto's JSON schema verbatim (FP-2). qCtx is derived from ctx, so canceling ctx (via
+	// stop()) aborts this fetch immediately, even if it is already in flight.
+	_, fetchErr := p.stage.Client.GetQueryInfo(qCtx, p.queryId, file)
+	qCancel()
+	closeErr := file.Close()
+	if fetchErr != nil || closeErr != nil {
+		// A canceled fetch must not leave a partial snapshot file behind, exactly like any
+		// other fetch/write error.
+		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+			log.Debug().Err(rmErr).Str("path", path).Msg("failed to remove incomplete json snapshot file")
+		}
+		if fetchErr != nil {
+			return fetchErr
+		}
+		return closeErr
+	}
+	p.seq = nextSeq
+	p.saved = append(p.saved, path)
+	p.applyRetention()
+	return nil
+}
+
+// applyRetention enforces the FP-5 retention policy. p.max <= 0 means unlimited (keep all).
+//
+// For p.max == 1 (N2): a single retained frame is far more useful as the latest observed
+// state than as the very first one, so this is special-cased to keep only the most recent
+// capture (rather than literally applying "keep #1 + the most recent max-1 = 0", which would
+// keep only the oldest and evict every later one - counter-intuitive for a user who asked
+// to retain exactly one snapshot).
+//
+// For p.max >= 2, the design's rule applies as specified: keep snapshot #1 (the earliest
+// frame preserves initial plan/queue state) plus the most recent (max-1) frames, deleting
+// the oldest-except-first snapshot as new ones arrive.
+func (p *jsonSnapshotPoller) applyRetention() {
+	if p.max <= 0 {
+		return
+	}
+	if p.max == 1 {
+		for len(p.saved) > 1 {
+			p.removeSnapshotFile(p.saved[0])
+			p.saved = p.saved[1:]
+		}
+		return
+	}
+	for len(p.saved) > p.max {
+		victim := p.saved[1]
+		p.removeSnapshotFile(victim)
+		p.saved = append(p.saved[:1], p.saved[2:]...)
+	}
+}
+
+// removeSnapshotFile deletes path, logging (but not failing on) any error other than the
+// file already being gone.
+func (p *jsonSnapshotPoller) removeSnapshotFile(path string) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Warn().Err(err).Str("path", path).Msg("failed to delete old json snapshot during retention")
+	}
+}
+
+// stop halts the poller; it is idempotent and safe to call on a nil receiver (the value
+// returned by startJsonSnapshotPoller when snapshotting is disabled for a query). It
+// cancels the context shared with every fetch (see startJsonSnapshotPoller/captureOnce),
+// so a fetch that is already in flight when stop() is called is aborted immediately rather
+// than left to complete (M1): wgExitMainStage still blocks the process from exiting until
+// run() actually returns (after that abort and its cleanup, i.e. the removal of the
+// now-incomplete snapshot file, have finished), so there is no truncated file left behind
+// and no premature process exit.
+func (p *jsonSnapshotPoller) stop() {
+	if p == nil {
+		return
+	}
+	p.stopOnce.Do(func() {
+		p.cancel()
+	})
+}

--- a/stage/json_snapshot_function_test.go
+++ b/stage/json_snapshot_function_test.go
@@ -1,0 +1,424 @@
+package stage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	presto "github.com/prestodb/presto-go-client/v2"
+	"github.com/prestodb/presto-go-client/v2/prestotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase-1 function tests (FT-1..FT-7), end-to-end oriented per design.md §8.2. They drive
+// the real Stage.Run() lifecycle (setDefaults/propagateStates/runQuery/saveQueryJsonFile)
+// against a mock Presto coordinator, rather than calling jsonSnapshotPoller methods
+// directly (see json_snapshot_test.go for those narrower unit tests).
+//
+// Deviation from design.md's illustrative timings: §4.1 fixes a 5s floor on the polling
+// interval (protects a real coordinator from excessive polling), but several FT-* examples
+// in §8.2 illustrate sub-floor intervals (e.g. "--snapshot-interval 3s", "interval 1s") for
+// brevity. To keep this suite's total runtime reasonable while still exercising the real,
+// floor-respecting production path end-to-end, these tests use interval=5s (the floor) or
+// larger wherever multiple ticks must be observed, and scale query durations accordingly.
+// FT-6's backoff/resume behavior is exercised via the same direct-poller technique used for
+// UT-6 (see TestSnapshotPoller_NeverPermanentlyDisabled_ResumesAfterRecovery and
+// TestSnapshotBackoffTicks_Sequence in json_snapshot_test.go), since it is already covered
+// end-to-end (real ticker, real HTTP, real backoff state machine) there, just without the
+// 5s floor, which would otherwise require ~30s of failing polls to observe recovery.
+//
+// M1 follow-up: stop() now cancels the context shared with every fetch (see
+// stage/json_snapshot.go), so a fetch already in flight when the query drains is aborted
+// deterministically instead of being left to run to completion. TestFT7_* below exercises
+// that hard guarantee end-to-end (superseding the previous "let the in-flight fetch finish"
+// behavior/test).
+
+// registerLatencyQuery registers a query template on mock sized so that the *poller's*
+// running window - i.e. the wall-clock time from when s.Client.Query() returns (and the
+// poller can start) to when the query fully drains - is approximately pollerWindow.
+//
+// MockPrestoServer.sendQueryResponse spreads Latency evenly across every request in the
+// statement lifecycle, INCLUDING the very first one (the initial POST /v1/statement that
+// s.Client.Query() itself blocks on before returning). With dataBatches data-fetch requests
+// plus 1 implicit queue request, that's dataBatches+1 total requests/sleeps; the first sleep
+// happens before Query() returns (and thus before the poller can start), so only
+// dataBatches of the dataBatches+1 sleeps occur during the poller's window. Using a large
+// dataBatches keeps that "lost" first slot a small, predictable fraction of the total.
+func registerLatencyQuery(mock *prestotest.MockPrestoServer, sql string, pollerWindow time.Duration) {
+	const dataBatches = 20
+	data := make([][]any, dataBatches)
+	for i := range data {
+		data[i] = []any{"row"}
+	}
+	totalRequests := dataBatches + 1 // +1 for the implicit QueueBatches=1 default
+	latency := pollerWindow * time.Duration(totalRequests) / time.Duration(dataBatches)
+	mock.AddQuery(&prestotest.MockQueryTemplate{
+		SQL:         sql,
+		DataBatches: dataBatches,
+		Columns:     []presto.Column{{Name: "_col0", Type: "varchar"}},
+		Data:        data,
+		Latency:     latency,
+	})
+}
+
+func newFunctionTestStage(id string, states *SharedStageStates) *Stage {
+	return &Stage{
+		Id:      id,
+		States:  states,
+		Catalog: strPtr("tpch"),
+		Schema:  strPtr("sf1"),
+	}
+}
+
+func strPtr(v string) *string { return &v }
+
+func snapshotDirFor(t *testing.T, s *Stage, sql string) string {
+	t.Helper()
+	result := &QueryResult{Query: &Query{Text: sql}}
+	return filepath.Join(s.States.OutputPath, s.querySourceString(result)+".snapshots")
+}
+
+// FT-1 (FP-1): a run-wide default applies to a plain stage; a sibling stage opts out via
+// save_json_snapshots=false; another sibling overrides json_snapshot_interval. Precedence
+// (per-stage JSON > CLI flag > built-in default) is proven both by inspecting the resolved
+// config and by the resulting file-system side effects.
+func TestFT1_ConfigPrecedenceEndToEnd(t *testing.T) {
+	mock := prestotest.NewMockPrestoServer()
+	defer mock.Close()
+	const q1, q2, q3 = "select 1", "select 2", "select 3"
+	registerLatencyQuery(mock, q1, 8*time.Second)
+	registerLatencyQuery(mock, q2, 8*time.Second)
+	registerLatencyQuery(mock, q3, 8*time.Second)
+
+	tmpDir := t.TempDir()
+	states := &SharedStageStates{
+		OutputPath:       tmpDir,
+		SnapshotsEnabled: true,
+		SnapshotInterval: 5 * time.Second, // the floor; the run-wide default
+		SnapshotMax:      0,
+		NewClient: func() *presto.Client {
+			c, _ := presto.NewClient(mock.URL())
+			return c
+		},
+	}
+
+	parent := newFunctionTestStage("parent", states)
+	parent.Queries = []string{}
+	parent.ColdRuns, parent.WarmRuns = intPtr(1), intPtr(0)
+
+	plainChild := newFunctionTestStage("plain_child", nil)
+	plainChild.Queries = []string{q1}
+
+	optOutChild := newFunctionTestStage("opt_out_child", nil)
+	optOutChild.Queries = []string{q2}
+	falseVal := false
+	optOutChild.SaveJsonSnapshots = &falseVal
+
+	overrideChild := newFunctionTestStage("override_child", nil)
+	overrideChild.Queries = []string{q3}
+	overrideInterval := "6s"
+	overrideChild.JsonSnapshotInterval = &overrideInterval
+
+	parent.NextStages = []*Stage{plainChild, optOutChild, overrideChild}
+	plainChild.wgPrerequisites.Add(1)
+	optOutChild.wgPrerequisites.Add(1)
+	overrideChild.wgPrerequisites.Add(1)
+
+	parent.Run(context.Background())
+
+	// Precedence proof via resolved config state.
+	assert.True(t, plainChild.snapshotsEnabled)
+	assert.Equal(t, 5*time.Second, plainChild.snapshotInterval, "plain stage should use the run-wide default")
+	assert.False(t, optOutChild.snapshotsEnabled, "stage explicitly opted out despite the run-wide default")
+	assert.True(t, overrideChild.snapshotsEnabled)
+	assert.Equal(t, 6*time.Second, overrideChild.snapshotInterval, "stage override must win over the run-wide default")
+
+	// End-to-end file-system proof.
+	plainDir := snapshotDirFor(t, plainChild, q1)
+	entries, err := os.ReadDir(plainDir)
+	require.NoError(t, err, "the plain (run-wide-default) stage should have produced a .snapshots dir")
+	assert.GreaterOrEqual(t, len(entries), 1)
+
+	optOutDir := snapshotDirFor(t, optOutChild, q2)
+	_, statErr := os.Stat(optOutDir)
+	assert.True(t, os.IsNotExist(statErr), "the opted-out stage must not produce a .snapshots dir")
+
+	overrideDir := snapshotDirFor(t, overrideChild, q3)
+	_, err = os.ReadDir(overrideDir)
+	require.NoError(t, err, "the override stage should also have produced a .snapshots dir")
+}
+
+// FT-2 (FP-2): snapshot files exist with verbatim payloads and correctly-formatted names.
+func TestFT2_SnapshotFilesVerbatimAndCorrectlyNamed(t *testing.T) {
+	mock := prestotest.NewMockPrestoServer()
+	defer mock.Close()
+	const q = "select 'ft2'"
+	registerLatencyQuery(mock, q, 12*time.Second)
+
+	tmpDir := t.TempDir()
+	s := newFunctionTestStage("ft2", &SharedStageStates{
+		OutputPath:       tmpDir,
+		SnapshotsEnabled: true,
+		SnapshotInterval: 5 * time.Second,
+		NewClient: func() *presto.Client {
+			c, _ := presto.NewClient(mock.URL())
+			return c
+		},
+	})
+	s.Queries = []string{q}
+	s.ColdRuns, s.WarmRuns = intPtr(1), intPtr(0)
+
+	s.Run(context.Background())
+
+	dir := snapshotDirFor(t, s, q)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(entries), 2, "an 11s query polled every 5s should yield at least 2 snapshots")
+
+	for i, e := range entries {
+		assert.True(t, strings.HasPrefix(e.Name(), "snapshot_"), "unexpected file name %s", e.Name())
+		assert.True(t, strings.HasSuffix(e.Name(), ".json"), "unexpected file name %s", e.Name())
+		content, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		require.NoError(t, readErr)
+		// The mock's /v1/query/{id} handler always returns a JSON object with a queryId field.
+		assert.Contains(t, string(content), `"queryId"`, "entry %d: %s", i, e.Name())
+	}
+}
+
+// FT-3 (FP-3): polling starts after submission and stops promptly on context cancellation
+// (the abort path); no snapshots are written after the poller stops. Cancellation is
+// triggered off observed poller activity (rather than a fixed sleep) so the test is not
+// sensitive to exact mock-server timing.
+func TestFT3_StartAfterSubmitAndStopOnContextCancel(t *testing.T) {
+	mock := prestotest.NewMockPrestoServer()
+	defer mock.Close()
+	const q = "select 'ft3'"
+	// Long poller window: the test cancels well before this query would finish naturally,
+	// so its exact length only needs to be "long enough", not tightly tuned.
+	registerLatencyQuery(mock, q, 30*time.Second)
+
+	tmpDir := t.TempDir()
+	// Set RunName explicitly (rather than relying on Run()'s default-to-s.Id, which it
+	// assigns concurrently at the start of Run()) so the test goroutine can compute the
+	// final output path itself without racing on a field Run() also mutates.
+	const runName = "ft3_run"
+	s := newFunctionTestStage("ft3", &SharedStageStates{
+		RunName:          runName,
+		OutputPath:       tmpDir,
+		SnapshotsEnabled: true,
+		SnapshotInterval: 5 * time.Second,
+		NewClient: func() *presto.Client {
+			c, _ := presto.NewClient(mock.URL())
+			return c
+		},
+	})
+	s.Queries = []string{q}
+	s.ColdRuns, s.WarmRuns = intPtr(1), intPtr(0)
+	trueVal := true
+	s.AbortOnError = &trueVal
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(runDone)
+	}()
+
+	result := &QueryResult{Query: &Query{Text: q}}
+	dir := filepath.Join(tmpDir, runName, s.querySourceString(result)+".snapshots")
+	require.Eventually(t, func() bool {
+		entries, _ := os.ReadDir(dir)
+		return len(entries) >= 1
+	}, 15*time.Second, 50*time.Millisecond, "polling should start once the query is submitted (FP-3)")
+
+	cancel()
+
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stage.Run did not return promptly after context cancellation")
+	}
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	countAfterRun := len(entries)
+
+	// No further snapshots should appear after Run() has returned (poller fully stopped).
+	time.Sleep(300 * time.Millisecond)
+	entries, err = os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, countAfterRun, len(entries), "no snapshots should be written after the poller stops")
+}
+
+// FT-4 (FP-4): with snapshots off, output is byte-identical to a snapshots-on run of the
+// same query (same deterministic query id, since each test uses a fresh mock server whose
+// query id counter starts at 0), and no .snapshots directory is created.
+func TestFT4_ByteIdenticalOutputWhenDisabled(t *testing.T) {
+	const q = "select 'ft4'"
+	runOnce := func(snapshotsOn bool) (terminalJSON []byte, colsJSON []byte, snapshotDirExists bool) {
+		mock := prestotest.NewMockPrestoServer()
+		defer mock.Close()
+		mock.AddQuery(&prestotest.MockQueryTemplate{
+			SQL:     q,
+			Columns: []presto.Column{{Name: "_col0", Type: "varchar"}},
+			Data:    [][]any{{"ft4"}},
+		})
+
+		tmpDir := t.TempDir()
+		s := newFunctionTestStage("ft4", &SharedStageStates{
+			OutputPath:       tmpDir,
+			SnapshotsEnabled: snapshotsOn,
+			SnapshotInterval: 5 * time.Second,
+			NewClient: func() *presto.Client {
+				c, _ := presto.NewClient(mock.URL())
+				return c
+			},
+		})
+		s.Queries = []string{q}
+		s.ColdRuns, s.WarmRuns = intPtr(1), intPtr(0)
+		trueVal := true
+		s.SaveJson = &trueVal
+		s.SaveColumnMetadata = &trueVal
+
+		s.Run(context.Background())
+
+		result := &QueryResult{Query: &Query{Text: q}}
+		base := s.querySourceString(result)
+		terminalJSON, err := os.ReadFile(filepath.Join(s.States.OutputPath, base+".json"))
+		require.NoError(t, err)
+		colsJSON, err = os.ReadFile(filepath.Join(s.States.OutputPath, base+".cols.json"))
+		require.NoError(t, err)
+		_, statErr := os.Stat(filepath.Join(s.States.OutputPath, base+".snapshots"))
+		return terminalJSON, colsJSON, statErr == nil
+	}
+
+	offTerminal, offCols, offDirExists := runOnce(false)
+	onTerminal, onCols, onDirExists := runOnce(true)
+
+	assert.False(t, offDirExists, "snapshots-off run must not produce a .snapshots directory")
+	assert.Equal(t, offTerminal, onTerminal, "terminal query json must be byte-identical regardless of snapshotting")
+	assert.Equal(t, offCols, onCols, "column metadata file must be byte-identical regardless of snapshotting")
+	// The snapshots-on run may or may not have captured a frame for this near-instant query,
+	// but if it exists, it must be the only difference in artifacts produced.
+	_ = onDirExists
+}
+
+// FT-5 (FP-5): retention keeps snapshot #1 plus the most recent (max-1) frames, exercised
+// end-to-end through Stage.Run() at the production floor interval.
+func TestFT5_RetentionEndToEnd(t *testing.T) {
+	mock := prestotest.NewMockPrestoServer()
+	defer mock.Close()
+	const q = "select 'ft5'"
+	registerLatencyQuery(mock, q, 17*time.Second) // ticks at ~5s, 10s, 15s => 3 captures
+
+	tmpDir := t.TempDir()
+	s := newFunctionTestStage("ft5", &SharedStageStates{
+		OutputPath:       tmpDir,
+		SnapshotsEnabled: true,
+		SnapshotInterval: 5 * time.Second,
+		SnapshotMax:      2,
+		NewClient: func() *presto.Client {
+			c, _ := presto.NewClient(mock.URL())
+			return c
+		},
+	})
+	s.Queries = []string{q}
+	s.ColdRuns, s.WarmRuns = intPtr(1), intPtr(0)
+
+	s.Run(context.Background())
+
+	dir := snapshotDirFor(t, s, q)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(entries), 2, "retention must cap the number of files at snapshot-max")
+	found1 := false
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "snapshot_000001_") {
+			found1 = true
+		}
+	}
+	assert.True(t, found1, "snapshot #1 must always be retained")
+}
+
+// FT-7 (FP-7 / M1): a snapshot fetch that is still in flight when the query completes is
+// aborted deterministically by stop() (M1's hard guarantee: the fetch's context is derived
+// from - and canceled together with - the poller's own context), rather than being left to
+// run to completion. wgExitMainStage still blocks Stage.Run() from returning until that
+// abort and its cleanup (removing the now-incomplete file) have finished - so there is no
+// truncated/partial file left on disk and no premature process exit - but Run() does not
+// wait for the full (stalled) response to arrive.
+func TestFT7_StopAbortsInFlightFetchOnQueryCompletion(t *testing.T) {
+	mock := prestotest.NewMockPrestoServer()
+	defer mock.Close()
+	const q = "select 'ft7'"
+	// Poller window ~6s: one tick fires at t~5s, comfortably before the query itself drains.
+	registerLatencyQuery(mock, q, 6*time.Second)
+
+	backend, err := url.Parse(mock.URL())
+	require.NoError(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(backend)
+
+	var fetchStarted, fetchAborted atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/query/{queryId}", func(w http.ResponseWriter, r *http.Request) {
+		fetchStarted.Store(true)
+		// Stall far longer than the query itself takes to drain, but respond to client-side
+		// cancellation (mirroring how a real coordinator's connection would be torn down)
+		// rather than the fixed 5s sleep the pre-M1 version of this test used.
+		select {
+		case <-time.After(5 * time.Second):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"queryId":"stalled-response-payload","state":"RUNNING"}`))
+		case <-r.Context().Done():
+			fetchAborted.Store(true)
+		}
+	})
+	mux.Handle("/", proxy)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	// Generous on purpose: proves the abort is caused by stop() (M1), not by the per-fetch
+	// timeout racing it.
+	fetchTimeout := "20s"
+	s := newFunctionTestStage("ft7", &SharedStageStates{
+		OutputPath:       tmpDir,
+		SnapshotsEnabled: true,
+		SnapshotInterval: 5 * time.Second,
+		NewClient: func() *presto.Client {
+			c, _ := presto.NewClient(srv.URL)
+			return c
+		},
+	})
+	s.Queries = []string{q}
+	s.ColdRuns, s.WarmRuns = intPtr(1), intPtr(0)
+	s.JsonSnapshotFetchTimeout = &fetchTimeout
+
+	start := time.Now()
+	s.Run(context.Background())
+	elapsed := time.Since(start)
+
+	require.True(t, fetchStarted.Load(), "the tick at t~5s should have started a fetch before the ~6.3s-long query drained")
+	assert.True(t, fetchAborted.Load(), "stop() should have canceled the in-flight fetch's context, observable server-side")
+	// The query itself drains at ~6.3s (registerLatencyQuery's poller-window formula). Run()
+	// must not wait for the full 5s stall (which would put elapsed at ~11.3s); a 9s
+	// threshold sits well below that but comfortably above "query-only" (~6.3s) plus normal
+	// scheduling slack, so a regression that goes back to waiting for the stalled fetch would
+	// fail this assertion.
+	assert.Less(t, elapsed, 9*time.Second, "Stage.Run() must not wait for the stalled fetch to complete")
+
+	dir := snapshotDirFor(t, s, q)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "the aborted in-flight fetch must not leave a partial (or complete) snapshot file behind")
+}

--- a/stage/json_snapshot_test.go
+++ b/stage/json_snapshot_test.go
@@ -1,0 +1,740 @@
+package stage
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	presto "github.com/prestodb/presto-go-client/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPollerTestStage builds a minimal Stage wired to a Presto client pointed at srvURL,
+// with wgExitMainStage ready for poller registration, for direct jsonSnapshotPoller unit
+// tests (UT-2..UT-7). It intentionally bypasses cmd/run.go and setDefaults()'s 5s interval
+// floor so tests can use short intervals and stay fast.
+func newPollerTestStage(t *testing.T, srvURL string) *Stage {
+	t.Helper()
+	client, err := presto.NewClient(srvURL)
+	require.NoError(t, err)
+	return &Stage{
+		Id:     "poller_test",
+		Client: client,
+		States: &SharedStageStates{
+			OutputPath:      t.TempDir(),
+			wgExitMainStage: &sync.WaitGroup{},
+		},
+	}
+}
+
+// UT-2: poller writes snapshot_<seq>_<epochms>.json files; content byte-equal to the mock response.
+func TestSnapshotCapture_WritesVerbatimContent(t *testing.T) {
+	payload := []byte(`{"queryId":"20260101_000000_00001_abcde","state":"RUNNING","weird":"NaN"}`)
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "base.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: time.Second, max: 0}
+
+	require.NoError(t, p.captureOnce(context.Background()))
+	assert.Equal(t, 1, p.seq)
+	require.Len(t, p.saved, 1)
+
+	name := filepath.Base(p.saved[0])
+	assert.True(t, strings.HasPrefix(name, "snapshot_000001_"), "unexpected file name %s", name)
+	assert.True(t, strings.HasSuffix(name, ".json"), "unexpected file name %s", name)
+
+	content, err := os.ReadFile(p.saved[0])
+	require.NoError(t, err)
+	assert.Equal(t, payload, content, "snapshot content must be byte-identical to the raw response")
+	assert.Equal(t, int32(1), reqCount.Load())
+
+	// A second capture advances seq and adds a second file.
+	require.NoError(t, p.captureOnce(context.Background()))
+	assert.Equal(t, 2, p.seq)
+	require.Len(t, p.saved, 2)
+	assert.True(t, strings.HasPrefix(filepath.Base(p.saved[1]), "snapshot_000002_"))
+}
+
+// UT-3 (part 1): poller start-after-submit / stop-on-drain via the Stage-level API, and
+// idempotent stop().
+func TestSnapshotPoller_StartStopLifecycle(t *testing.T) {
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	s.States.SnapshotsEnabled = true
+	s.States.SnapshotInterval = 30 * time.Second // will be resolved/floored; overridden below
+	s.setDefaults()
+	// Bypass the 5s production floor for a fast test.
+	s.snapshotInterval = 15 * time.Millisecond
+	s.snapshotFetchTimeout = 15 * time.Millisecond
+
+	result := &QueryResult{QueryId: "q1", Query: &Query{}}
+	poller := s.startJsonSnapshotPoller(context.Background(), result)
+	require.NotNil(t, poller, "poller must start once snapshotting is enabled and the query id is known")
+
+	// Let a few ticks happen.
+	require.Eventually(t, func() bool { return reqCount.Load() >= 2 }, 2*time.Second, 10*time.Millisecond)
+
+	poller.stop()
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+
+	countAfterStop := reqCount.Load()
+	time.Sleep(80 * time.Millisecond)
+	assert.Equal(t, countAfterStop, reqCount.Load(), "no more polling should happen after stop()")
+
+	// stop() must be idempotent.
+	poller.stop()
+	poller.stop()
+
+	// stop() on a nil poller (disabled case) must be a safe no-op.
+	var nilPoller *jsonSnapshotPoller
+	nilPoller.stop()
+}
+
+// UT-3 (part 2): the poller stops when the stage context is canceled (abort path).
+func TestSnapshotPoller_StopsOnContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	s.setDefaults()
+	s.snapshotsEnabled = true
+	s.snapshotInterval = 15 * time.Millisecond
+	s.snapshotFetchTimeout = 15 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := &QueryResult{QueryId: "q1", Query: &Query{}}
+	poller := s.startJsonSnapshotPoller(ctx, result)
+	require.NotNil(t, poller)
+
+	time.Sleep(40 * time.Millisecond)
+	cancel()
+
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+}
+
+// UT-3 (part 3): a fetch slower than the interval never overlaps with the next tick - the
+// ticker naturally coalesces/drops ticks while captureOnce is in flight (design.md §4.2).
+func TestSnapshotPoller_SlowFetchNeverOverlaps(t *testing.T) {
+	const fetchDelay = 120 * time.Millisecond
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := inFlight.Add(1)
+		for {
+			cur := maxInFlight.Load()
+			if n <= cur || maxInFlight.CompareAndSwap(cur, n) {
+				break
+			}
+		}
+		reqCount.Add(1)
+		time.Sleep(fetchDelay)
+		inFlight.Add(-1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "slow.snapshots")
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &jsonSnapshotPoller{
+		stage: s, queryId: "q1", dir: dir,
+		interval: 20 * time.Millisecond, fetchTimeout: time.Second, max: 0,
+		cancel: cancel,
+	}
+	s.States.wgExitMainStage.Add(1)
+	go p.run(ctx)
+
+	// Run for enough wall-clock time that, without tick-coalescing, dozens of ticks
+	// (interval=20ms) would have fired; with coalescing, only a handful of fetches (limited
+	// by fetchDelay=120ms) should actually happen.
+	time.Sleep(500 * time.Millisecond)
+	p.stop()
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+
+	assert.LessOrEqual(t, int32(1), maxInFlight.Load())
+	assert.Equal(t, int32(1), maxInFlight.Load(), "fetches must never overlap")
+	assert.Less(t, int(reqCount.Load()), 10, "slow fetches should cause ticks to be dropped, not queued")
+	assert.GreaterOrEqual(t, int(reqCount.Load()), 2, "at least a couple of fetches should have completed")
+}
+
+// M1: captureOnce must abort deterministically - and clean up any partial file - when its
+// context is canceled mid-fetch, regardless of scheduler timing. This is the mechanism
+// stop() now relies on (see startJsonSnapshotPoller/stop()) to make "no capture proceeds
+// after stop()" a hard guarantee rather than a best-effort race.
+func TestSnapshotCapture_CanceledContextAbortsAndCleansUpPartialFile(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "cancel.snapshots")
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: 10 * time.Second, max: 0, cancel: cancel}
+
+	// Cancel while the fetch is in flight, simulating stop() racing an in-flight capture.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := p.captureOnce(ctx)
+	assert.Error(t, err, "a fetch whose context is canceled mid-flight must fail (capture returns due to the canceled ctx)")
+	assert.Equal(t, 0, p.seq, "seq must not advance when the fetch is canceled")
+	assert.Empty(t, p.saved)
+
+	entries, readErr := os.ReadDir(dir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "a canceled fetch must not leave a partial snapshot file behind")
+}
+
+// M1: deterministically forces the exact interleaving the fix targets - a tick already
+// buffered in ticker.C (interval=10ms) while a first capture is blocked in flight, then
+// stop() called while that first capture is still in flight - and asserts no second
+// capture is ever started, regardless of which case Go's select happens to pick once the
+// first capture unblocks. Before the fix, this could let one extra frame through (see
+// review finding M1); the hard guarantee comes from tying every fetch's context to the same
+// cancelable context stop() cancels, not from the (still present, best-effort) priority
+// check in run().
+func TestSnapshotPoller_StopDeterministicallyPreventsFurtherCaptures(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqCount.Add(1) == 1 {
+			// The first fetch blocks well past one more tick interval, so a second tick has
+			// time to buffer in ticker.C before stop() is called and this unblocks.
+			select {
+			case <-release:
+			case <-r.Context().Done():
+			}
+			return
+		}
+		// A second request must never arrive; if it did (the bug this test targets), let it
+		// succeed instantly so the failure is about reqCount, not a hang.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "poststop.snapshots")
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &jsonSnapshotPoller{
+		stage: s, queryId: "q1", dir: dir,
+		interval: 10 * time.Millisecond, fetchTimeout: 10 * time.Second, max: 0,
+		cancel: cancel,
+	}
+	s.States.wgExitMainStage.Add(1)
+	go p.run(ctx)
+
+	// Wait for the first fetch to actually start.
+	require.Eventually(t, func() bool { return reqCount.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
+	// Let a second (and likely third) tick buffer/coalesce in ticker.C while the first fetch
+	// is still blocked (interval=10ms << this 50ms wait).
+	time.Sleep(50 * time.Millisecond)
+
+	p.stop() // cancels ctx: aborts the in-flight first fetch AND must prevent any buffered tick's capture.
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+
+	// Give a wrongly-started second request a moment to arrive, if the bug were present.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(1), reqCount.Load(), "no capture must be started after stop(), even with a tick already buffered")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "the aborted first capture must not leave a partial file, and no second capture must have run")
+}
+
+// UT-4: save_json_snapshots=false (disabled) -> no .snapshots dir, no extra HTTP calls;
+// startJsonSnapshotPoller must be a pure no-op.
+func TestSnapshotDisabled_NoDirNoRequests(t *testing.T) {
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	s.setDefaults() // States is zero-value -> snapshotsEnabled stays false
+
+	result := &QueryResult{QueryId: "q1", Query: &Query{}}
+	poller := s.startJsonSnapshotPoller(context.Background(), result)
+	assert.Nil(t, poller)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), reqCount.Load(), "no /v1/query polls should happen when snapshotting is disabled")
+
+	dir := filepath.Join(s.States.OutputPath, s.querySourceString(result)+".snapshots")
+	_, statErr := os.Stat(dir)
+	assert.True(t, os.IsNotExist(statErr), "no .snapshots directory should be created")
+
+	// A nil poller's stop() must be a safe no-op (mirrors the `defer poller.stop()` call
+	// site in runQuery(), which does not nil-check).
+	poller.stop()
+}
+
+// UT-4 (part 2): also disabled when the query id is not yet known (submit error path).
+func TestSnapshotDisabled_NoQueryId(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	s.setDefaults()
+	s.snapshotsEnabled = true
+
+	result := &QueryResult{QueryId: "", Query: &Query{}}
+	poller := s.startJsonSnapshotPoller(context.Background(), result)
+	assert.Nil(t, poller)
+}
+
+// N1: enabled but a query that drains before its first tick fires (or one that is stopped
+// before any tick fires) must leave no .snapshots directory behind - the directory is now
+// created lazily on the first attempted capture (captureOnce), not eagerly when the poller
+// starts.
+func TestSnapshotEnabled_NoDirWhenNoTickEverFires(t *testing.T) {
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	s.setDefaults()
+	s.snapshotsEnabled = true
+	s.snapshotInterval = time.Hour // will certainly not tick during this test
+	s.snapshotFetchTimeout = time.Hour
+
+	result := &QueryResult{QueryId: "q1", Query: &Query{}}
+	poller := s.startJsonSnapshotPoller(context.Background(), result)
+	require.NotNil(t, poller)
+
+	time.Sleep(30 * time.Millisecond)
+	poller.stop()
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+
+	assert.Equal(t, int32(0), reqCount.Load(), "no fetch should have been attempted")
+	dir := filepath.Join(s.States.OutputPath, s.querySourceString(result)+".snapshots")
+	_, statErr := os.Stat(dir)
+	assert.True(t, os.IsNotExist(statErr), "no .snapshots directory should be created when no tick ever fires (N1)")
+}
+
+// UT-5: retention keeps snapshot #1 plus the most recent (max-1) frames.
+// max=3 over 6 successful captures keeps snapshots {1,5,6}.
+func TestSnapshotRetention_KeepsFirstAndMostRecent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "retention.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: time.Second, max: 3}
+
+	for i := 0; i < 6; i++ {
+		require.NoError(t, p.captureOnce(context.Background()))
+		time.Sleep(2 * time.Millisecond) // ensure distinct epoch-millis in file names
+	}
+
+	assert.Len(t, p.saved, 3)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 3, "exactly max=3 files should remain on disk")
+
+	var seqs []int
+	for _, e := range entries {
+		var seq int
+		var ts int64
+		_, scanErr := fmt.Sscanf(e.Name(), "snapshot_%06d_%d.json", &seq, &ts)
+		require.NoError(t, scanErr)
+		seqs = append(seqs, seq)
+	}
+	sort.Ints(seqs)
+	assert.Equal(t, []int{1, 5, 6}, seqs)
+}
+
+// UT-5 (part 2): max=0 (unlimited) never deletes anything.
+func TestSnapshotRetention_UnlimitedKeepsAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "unlimited.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: time.Second, max: 0}
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, p.captureOnce(context.Background()))
+		time.Sleep(2 * time.Millisecond)
+	}
+	assert.Len(t, p.saved, 5)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 5)
+}
+
+// UT-5 (part 3, N2): max=1 is special-cased to keep the most recent frame, not the oldest.
+// Literally applying "keep #1 + most-recent (max-1=0)" would keep only the very first
+// snapshot forever and evict every later one - useless for a user who asked to retain
+// exactly one frame, who almost certainly wants the latest state. See applyRetention().
+func TestSnapshotRetention_MaxOneKeepsLatestNotOldest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "max_one.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: time.Second, max: 1}
+
+	for i := 0; i < 4; i++ {
+		require.NoError(t, p.captureOnce(context.Background()))
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	require.Len(t, p.saved, 1)
+	assert.True(t, strings.HasPrefix(filepath.Base(p.saved[0]), "snapshot_000004_"),
+		"max=1 should retain the most recent (4th) capture, not the first")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, strings.HasPrefix(entries[0].Name(), "snapshot_000004_"))
+}
+
+// UT-6: fetch errors (500) are logged and never fail the query; exponential backoff skips
+// 1,2,4,8,8... ticks; success resets the streak; the poller is never permanently disabled -
+// it resumes capturing once the mock server recovers.
+func TestSnapshotBackoffTicks_Sequence(t *testing.T) {
+	assert.Equal(t, 0, snapshotBackoffTicks(0))
+	assert.Equal(t, 1, snapshotBackoffTicks(1))
+	assert.Equal(t, 2, snapshotBackoffTicks(2))
+	assert.Equal(t, 4, snapshotBackoffTicks(3))
+	assert.Equal(t, 8, snapshotBackoffTicks(4))
+	assert.Equal(t, 8, snapshotBackoffTicks(5))
+	assert.Equal(t, 8, snapshotBackoffTicks(10))
+}
+
+func TestSnapshotPoller_NeverPermanentlyDisabled_ResumesAfterRecovery(t *testing.T) {
+	var reqCount atomic.Int32
+	const failCount = 6
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := reqCount.Add(1)
+		if n <= failCount {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "resume.snapshots")
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &jsonSnapshotPoller{
+		stage: s, queryId: "q1", dir: dir,
+		interval: 15 * time.Millisecond, fetchTimeout: time.Second, max: 0,
+		cancel: cancel,
+	}
+	s.States.wgExitMainStage.Add(1)
+	go p.run(ctx)
+
+	// Wait on the atomic request counter (not p.seq/p.failStreak, which are only touched by
+	// the poller goroutine and unsafe to read concurrently without synchronization - they
+	// are read further below, but only after waitForWaitGroup establishes a happens-before
+	// relationship via the poller's exit) until the mock has served at least one successful
+	// response past the failure run.
+	require.Eventually(t, func() bool {
+		return int(reqCount.Load()) > failCount
+	}, 10*time.Second, 5*time.Millisecond,
+		"poller must resume issuing requests after the mock coordinator recovers (never permanently disabled)")
+
+	// Give the corresponding successful capture a brief moment to land on disk. (Checking
+	// the directory during the failure run itself would be racy: a failed capture creates
+	// the file before removing it, so it can transiently appear in a directory listing.)
+	require.Eventually(t, func() bool {
+		entries, _ := os.ReadDir(dir)
+		return len(entries) > 0
+	}, 2*time.Second, 10*time.Millisecond, "the successful capture should have been written to disk")
+
+	p.stop()
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+
+	assert.GreaterOrEqual(t, int(reqCount.Load()), failCount+1)
+	assert.Equal(t, 0, p.failStreak, "a successful capture must reset the failure streak")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(entries), 1)
+}
+
+// UT-6 (M3): a 404 - the query aged out of coordinator memory, design.md §4.5 - flows
+// through the same non-200 error path as any other fetch failure: the partial file is
+// removed, no seq/saved advance, and the poller backs off exactly like a 500 or timeout
+// (never permanently disabled).
+func TestSnapshotFetchError_404AgedOutOfCoordinatorMemory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "notfound.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: time.Second, max: 0}
+
+	err := p.captureOnce(context.Background())
+	assert.Error(t, err, "a 404 (query aged out of coordinator memory) must be treated as a fetch failure")
+	assert.Equal(t, 0, p.seq, "seq must not advance on a 404")
+	assert.Empty(t, p.saved)
+
+	entries, readErr := os.ReadDir(dir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "the partial file for a 404 response must be removed")
+
+	// Exercised through the full run() loop too, to prove backoff (FP-6) applies identically
+	// to a 404 as it does to a 500/timeout, and that the poller keeps retrying afterwards.
+	var reqCount atomic.Int32
+	const failCount = 3
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqCount.Add(1) <= failCount {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv2.Close()
+
+	s2 := newPollerTestStage(t, srv2.URL)
+	dir2 := filepath.Join(s2.States.OutputPath, "notfound_resume.snapshots")
+	ctx, cancel := context.WithCancel(context.Background())
+	p2 := &jsonSnapshotPoller{
+		stage: s2, queryId: "q1", dir: dir2,
+		interval: 10 * time.Millisecond, fetchTimeout: time.Second, max: 0,
+		cancel: cancel,
+	}
+	s2.States.wgExitMainStage.Add(1)
+	go p2.run(ctx)
+
+	require.Eventually(t, func() bool {
+		return int(reqCount.Load()) > failCount
+	}, 10*time.Second, 5*time.Millisecond, "poller must keep retrying (never permanently disabled) after repeated 404s")
+	require.Eventually(t, func() bool {
+		entries, _ := os.ReadDir(dir2)
+		return len(entries) > 0
+	}, 2*time.Second, 10*time.Millisecond, "the successful capture after recovery should have been written to disk")
+
+	p2.stop()
+	waitForWaitGroup(t, s2.States.wgExitMainStage, 2*time.Second)
+}
+
+func TestSnapshotCapture_ErrorRemovesPartialFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "err.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: time.Second, max: 0}
+
+	err := p.captureOnce(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, 0, p.seq, "seq must not advance on failure")
+	assert.Empty(t, p.saved)
+
+	entries, readErr := os.ReadDir(dir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "the partially-written file must be removed on error")
+}
+
+// UT-7: per-fetch timeout is honored (a stalled fetch is aborted) and is overridable
+// (raising it lets an otherwise-too-slow fetch succeed).
+func TestSnapshotFetchTimeout_Honored(t *testing.T) {
+	unblock := make(chan struct{})
+	defer close(unblock)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "timeout.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: 50 * time.Millisecond, max: 0}
+
+	start := time.Now()
+	err := p.captureOnce(context.Background())
+	elapsed := time.Since(start)
+	assert.Error(t, err, "a fetch stalled past the timeout must fail")
+	assert.Less(t, elapsed, time.Second, "the fetch should have been aborted by the per-fetch timeout, not run forever")
+}
+
+func TestSnapshotFetchTimeout_OverridableForSlowQueries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(80 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	dir := filepath.Join(s.States.OutputPath, "timeout_override.snapshots")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	// A 500ms timeout comfortably accommodates an 80ms-slow coordinator response.
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: 500 * time.Millisecond, max: 0}
+
+	assert.NoError(t, p.captureOnce(context.Background()))
+	assert.Equal(t, 1, p.seq)
+}
+
+// UT-7 (wgExitMainStage accounting): the poller's goroutine must be registered on
+// wgExitMainStage for as long as run() is executing - including through an in-flight
+// fetch's abort and cleanup when stop() is called (M1) - and Wait() must not return before
+// run() actually exits. The mock handler respects client-side cancellation (r.Context()),
+// mirroring how a real coordinator's connection would be torn down once stop() cancels the
+// fetch's context; it deliberately does NOT unblock on its own, so if run()/captureOnce
+// regressed to waiting for the response instead of aborting, this test would hang/time out
+// rather than pass.
+func TestSnapshotPoller_RegistersOnWgExitMainStage(t *testing.T) {
+	handlerEntered := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerEntered)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	s := newPollerTestStage(t, srv.URL)
+	s.setDefaults()
+	s.snapshotsEnabled = true
+	s.snapshotInterval = 10 * time.Millisecond
+	s.snapshotFetchTimeout = 5 * time.Second
+
+	result := &QueryResult{QueryId: "q1", Query: &Query{}}
+	poller := s.startJsonSnapshotPoller(context.Background(), result)
+	require.NotNil(t, poller)
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the poller never started a fetch")
+	}
+
+	poller.stop()
+	waitForWaitGroup(t, s.States.wgExitMainStage, 2*time.Second)
+
+	// The aborted fetch must not have left a partial (or complete) snapshot file behind.
+	dir := filepath.Join(s.States.OutputPath, s.querySourceString(result)+".snapshots")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// waitForWaitGroup waits for wg to reach zero, failing the test if it takes longer than d.
+func waitForWaitGroup(t *testing.T, wg *sync.WaitGroup, d time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatal("timed out waiting for wgExitMainStage to reach zero")
+	}
+}
+
+// B-1: BenchmarkSnapshotCapture - one captureOnce against a 10MB payload. max=1 bounds disk
+// usage across b.N iterations (each new capture immediately evicts the prior one, since
+// only snapshot #1 is ever retained when max=1); this does not affect the measured cost,
+// which is dominated by the io.Copy of the response body.
+func BenchmarkSnapshotCapture(b *testing.B) {
+	payload := make([]byte, 10*1024*1024)
+	for i := range payload {
+		payload[i] = byte('a' + i%26)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	client, err := presto.NewClient(srv.URL)
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := &Stage{
+		Id:     "bench",
+		Client: client,
+		States: &SharedStageStates{OutputPath: b.TempDir(), wgExitMainStage: &sync.WaitGroup{}},
+	}
+	dir := filepath.Join(s.States.OutputPath, "bench.snapshots")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		b.Fatal(err)
+	}
+	p := &jsonSnapshotPoller{stage: s, queryId: "q1", dir: dir, fetchTimeout: 30 * time.Second, max: 1}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := p.captureOnce(context.Background()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/stage/stage.go
+++ b/stage/stage.go
@@ -96,8 +96,24 @@ type Stage struct {
 	// Children stages will inherit this value from their parent if it is not set.
 	// When a query failed to execute for whatever reason, a query json file will be automatically saved even if this
 	// knob was not set to true.
-	SaveJson       *bool    `json:"save_json,omitempty"`
-	NextStagePaths []string `json:"next,omitempty"`
+	SaveJson *bool `json:"save_json,omitempty"`
+	// If SaveJsonSnapshots is set, it overrides the run-wide --snapshots default for
+	// this stage (and its children via inheritance). When true, pbench periodically
+	// fetches /v1/query/{queryId} while the query runs and saves each raw response as
+	// an additional snapshot file.
+	// DIAGNOSTIC MODE: adds coordinator load; do not enable on timed baseline runs.
+	// The terminal query json file is unaffected.
+	SaveJsonSnapshots *bool `json:"save_json_snapshots,omitempty"`
+	// Go duration string, e.g. "30s". Overrides --snapshot-interval when set.
+	JsonSnapshotInterval *string `json:"json_snapshot_interval,omitempty"`
+	// Maximum snapshots retained per query; overrides --snapshot-max when set.
+	// Default (via the flag) is 20; 0 means unlimited and must be set explicitly.
+	// When exceeded, the oldest snapshot except the very first is deleted.
+	JsonSnapshotMax *int `json:"json_snapshot_max,omitempty" validate:"omitempty,gte=0"`
+	// Per-fetch timeout as a Go duration string; overrides --snapshot-fetch-timeout.
+	// Default: the polling interval. Raise for very large queries on busy coordinators.
+	JsonSnapshotFetchTimeout *string  `json:"json_snapshot_fetch_timeout,omitempty"`
+	NextStagePaths           []string `json:"next,omitempty"`
 	// StreamCount specifies how many parallel instances of this stage should run.
 	// Each stream gets a deterministically derived seed for reproducible randomization.
 	// Not inherited by child stages.
@@ -122,6 +138,14 @@ type Stage struct {
 	currentCatalog  string
 	currentSchema   string
 	currentTimeZone string
+	// snapshotsEnabled, snapshotInterval, snapshotMax, and snapshotFetchTimeout are the
+	// effective, fully-resolved snapshot settings for this stage, computed once in
+	// setDefaults() from the precedence: per-stage JSON value > CLI flag (SharedStageStates)
+	// > built-in default. See resolveSnapshotSettings() in stage/json_snapshot.go.
+	snapshotsEnabled     bool
+	snapshotInterval     time.Duration
+	snapshotMax          int
+	snapshotFetchTimeout time.Duration
 	// wgPrerequisites is a count-down latch to wait for all the prerequisites to finish before starting this stage.
 	wgPrerequisites sync.WaitGroup
 
@@ -371,6 +395,10 @@ func (s *Stage) newStreamInstance(index int) *Stage {
 		SaveOutput:                 s.SaveOutput,
 		SaveColumnMetadata:         s.SaveColumnMetadata,
 		SaveJson:                   s.SaveJson,
+		SaveJsonSnapshots:          s.SaveJsonSnapshots,
+		JsonSnapshotInterval:       s.JsonSnapshotInterval,
+		JsonSnapshotMax:            s.JsonSnapshotMax,
+		JsonSnapshotFetchTimeout:   s.JsonSnapshotFetchTimeout,
 		PreQueryShellScripts:       s.PreQueryShellScripts,
 		PostQueryShellScripts:      s.PostQueryShellScripts,
 		PreQueryCycleShellScripts:  s.PreQueryCycleShellScripts,
@@ -381,6 +409,10 @@ func (s *Stage) newStreamInstance(index int) *Stage {
 		currentCatalog:             s.currentCatalog,
 		currentSchema:              s.currentSchema,
 		currentTimeZone:            s.currentTimeZone,
+		snapshotsEnabled:           s.snapshotsEnabled,
+		snapshotInterval:           s.snapshotInterval,
+		snapshotMax:                s.snapshotMax,
+		snapshotFetchTimeout:       s.snapshotFetchTimeout,
 	}
 }
 
@@ -670,6 +702,13 @@ func (s *Stage) runQuery(ctx context.Context, query *Query) (result *QueryResult
 	if err != nil {
 		return result, err
 	}
+
+	// Start periodic query JSON snapshotting (diagnostic mode, opt-in). Returns nil (a
+	// no-op poller.stop()) when snapshotting is disabled for this stage. defer guarantees
+	// the poller stops on every exit path of runQuery (drain complete, drain error,
+	// post-query script error, panic-recover). See stage/json_snapshot.go.
+	poller := s.startJsonSnapshotPoller(ctx, result)
+	defer poller.stop()
 
 	// Log query submission
 	e := log.Info().EmbedObject(result.SimpleLogging())

--- a/stage/stage_test.go
+++ b/stage/stage_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"pbench/log"
 	"strconv"
 	"strings"
 	"sync"
@@ -1008,4 +1009,231 @@ func TestQueryFileDirectoryWithPreStageScript(t *testing.T) {
 	assert.Equal(t, 2, len(queryTexts))
 	assert.Equal(t, "select 'query 1'", queryTexts[0])
 	assert.Equal(t, "select 'query 2'", queryTexts[1])
+}
+
+// --- UT-1 / UT-8: snapshot config resolution (FP-1) ---
+//
+// These tests exercise resolveSnapshotSettings() (called from setDefaults()) and
+// propagateStates() directly, without spinning up a mock coordinator, to prove the fixed
+// precedence: per-stage JSON value > CLI flag (SharedStageStates run-wide default) >
+// built-in default.
+
+func newSnapshotTestStage(states *SharedStageStates) *Stage {
+	s := &Stage{Id: "snapshot_test_stage", States: states}
+	return s
+}
+
+func TestSnapshotConfigResolution_RunWideDefaultAppliesToPlainStage(t *testing.T) {
+	// CLI flags (simulated via SharedStageStates) become the run-wide default for a stage
+	// that does not set any per-stage override.
+	states := &SharedStageStates{
+		SnapshotsEnabled: true,
+		SnapshotInterval: 10 * time.Second,
+		SnapshotMax:      7,
+		// SnapshotFetchTimeout left at zero -> "use the interval".
+	}
+	s := newSnapshotTestStage(states)
+	s.setDefaults()
+
+	assert.True(t, s.snapshotsEnabled)
+	assert.Equal(t, 10*time.Second, s.snapshotInterval)
+	assert.Equal(t, 7, s.snapshotMax)
+	assert.Equal(t, 10*time.Second, s.snapshotFetchTimeout, "fetch timeout should default to the interval")
+}
+
+func TestSnapshotConfigResolution_StageCanOptOutUnderRunWideSnapshots(t *testing.T) {
+	// --snapshots turns snapshots on run-wide; a stage can opt out explicitly.
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 30 * time.Second, SnapshotMax: 20}
+	falseVal := false
+	s := newSnapshotTestStage(states)
+	s.SaveJsonSnapshots = &falseVal
+	s.setDefaults()
+
+	assert.False(t, s.snapshotsEnabled)
+}
+
+func TestSnapshotConfigResolution_StageCanOptInWithoutRunWideSnapshots(t *testing.T) {
+	// A stage can opt in on an otherwise snapshot-free run.
+	states := &SharedStageStates{SnapshotsEnabled: false, SnapshotInterval: 30 * time.Second, SnapshotMax: 20}
+	trueVal := true
+	s := newSnapshotTestStage(states)
+	s.SaveJsonSnapshots = &trueVal
+	s.setDefaults()
+
+	assert.True(t, s.snapshotsEnabled)
+}
+
+func TestSnapshotConfigResolution_PerStageOverridesInterval(t *testing.T) {
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 30 * time.Second, SnapshotMax: 20}
+	interval := "15s"
+	s := newSnapshotTestStage(states)
+	s.JsonSnapshotInterval = &interval
+	s.setDefaults()
+
+	assert.Equal(t, 15*time.Second, s.snapshotInterval)
+	assert.Equal(t, 15*time.Second, s.snapshotFetchTimeout, "fetch timeout should default to the resolved (per-stage) interval")
+}
+
+func TestSnapshotConfigResolution_PerStageOverridesMaxAndFetchTimeout(t *testing.T) {
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 30 * time.Second, SnapshotMax: 20}
+	max := 40
+	fetchTimeout := "60s"
+	s := newSnapshotTestStage(states)
+	s.JsonSnapshotMax = &max
+	s.JsonSnapshotFetchTimeout = &fetchTimeout
+	s.setDefaults()
+
+	assert.Equal(t, 40, s.snapshotMax)
+	assert.Equal(t, 60*time.Second, s.snapshotFetchTimeout)
+}
+
+func TestSnapshotConfigResolution_ExplicitZeroMaxMeansUnlimited(t *testing.T) {
+	// json_snapshot_max: 0 (explicit, non-nil pointer) means unlimited for this stage, even
+	// though the run-wide/CLI default (simulated here as 20, as the --snapshot-max flag's
+	// own registered default would produce) is non-zero.
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 30 * time.Second, SnapshotMax: 20}
+	zero := 0
+	s := newSnapshotTestStage(states)
+	s.JsonSnapshotMax = &zero
+	s.setDefaults()
+
+	assert.Equal(t, 0, s.snapshotMax)
+}
+
+func TestSnapshotConfigResolution_BuiltInDefaults(t *testing.T) {
+	// With no per-stage override and a zero-value SharedStageStates (as if --snapshot-max
+	// 20 / --snapshot-interval 30s were never explicitly threaded through, e.g. a stage
+	// constructed directly in a test), the stage package's own built-in defaults apply for
+	// interval (nonsensical at zero) while an unset run-wide max (0) is treated as unlimited
+	// -- exactly like an explicit override would be. Real runs always populate
+	// SharedStageStates.SnapshotMax from the --snapshot-max flag, whose own default is 20.
+	states := &SharedStageStates{}
+	s := newSnapshotTestStage(states)
+	s.setDefaults()
+
+	assert.False(t, s.snapshotsEnabled)
+	assert.Equal(t, DefaultSnapshotInterval, s.snapshotInterval)
+	assert.Equal(t, DefaultSnapshotInterval, s.snapshotFetchTimeout)
+}
+
+func TestSnapshotConfigResolution_CLIFlagDefaultMax(t *testing.T) {
+	// Simulates the actual --snapshot-max flag default (20) being threaded through
+	// SharedStageStates, as cmd/run.go does.
+	states := &SharedStageStates{SnapshotMax: DefaultSnapshotMax}
+	s := newSnapshotTestStage(states)
+	s.setDefaults()
+
+	assert.Equal(t, DefaultSnapshotMax, s.snapshotMax)
+}
+
+func TestSnapshotConfigResolution_InheritedByGrandchildStages(t *testing.T) {
+	// propagateStates() must inherit unset per-stage overrides down the DAG, exactly like
+	// SaveJson.
+	states := &SharedStageStates{SnapshotsEnabled: false, SnapshotInterval: 30 * time.Second, SnapshotMax: 20}
+	trueVal := true
+	interval := "20s"
+	parent := newSnapshotTestStage(states)
+	parent.SaveJsonSnapshots = &trueVal
+	parent.JsonSnapshotInterval = &interval
+
+	child := &Stage{Id: "child"}
+	grandchild := &Stage{Id: "grandchild"}
+	parent.NextStages = []*Stage{child}
+	child.NextStages = []*Stage{grandchild}
+
+	parent.setDefaults()
+	parent.propagateStates()
+	assert.NotNil(t, child.SaveJsonSnapshots)
+	assert.True(t, *child.SaveJsonSnapshots)
+	assert.NotNil(t, child.JsonSnapshotInterval)
+	assert.Equal(t, "20s", *child.JsonSnapshotInterval)
+
+	child.setDefaults()
+	child.propagateStates()
+	assert.True(t, child.snapshotsEnabled)
+	assert.Equal(t, 20*time.Second, child.snapshotInterval)
+	assert.NotNil(t, grandchild.SaveJsonSnapshots)
+	assert.True(t, *grandchild.SaveJsonSnapshots)
+	assert.NotNil(t, grandchild.JsonSnapshotInterval)
+	assert.Equal(t, "20s", *grandchild.JsonSnapshotInterval)
+
+	grandchild.setDefaults()
+	assert.True(t, grandchild.snapshotsEnabled)
+	assert.Equal(t, 20*time.Second, grandchild.snapshotInterval)
+}
+
+func TestSnapshotConfigResolution_MergeWith(t *testing.T) {
+	// MergeWith() must copy the four override fields exactly like SaveJson.
+	base := &Stage{}
+	trueVal := true
+	max := 5
+	interval := "45s"
+	fetchTimeout := "90s"
+	other := &Stage{
+		SaveJsonSnapshots:        &trueVal,
+		JsonSnapshotInterval:     &interval,
+		JsonSnapshotMax:          &max,
+		JsonSnapshotFetchTimeout: &fetchTimeout,
+	}
+	base.MergeWith(other)
+
+	assert.Same(t, other.SaveJsonSnapshots, base.SaveJsonSnapshots)
+	assert.Same(t, other.JsonSnapshotInterval, base.JsonSnapshotInterval)
+	assert.Same(t, other.JsonSnapshotMax, base.JsonSnapshotMax)
+	assert.Same(t, other.JsonSnapshotFetchTimeout, base.JsonSnapshotFetchTimeout)
+}
+
+// UT-8: unparsable json_snapshot_interval disables snapshots for the stage (never fatal)
+// and logs an error; a sub-floor interval is clamped to the 5s floor with a warning.
+func TestSnapshotIntervalValidation_UnparsableDisablesStageSnapshots(t *testing.T) {
+	buf := new(strings.Builder)
+	log.SetGlobalLogger(log.Output(buf))
+	defer log.SetGlobalLogger(log.Output(os.Stderr))
+
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 30 * time.Second}
+	bogus := "not-a-duration"
+	s := newSnapshotTestStage(states)
+	s.JsonSnapshotInterval = &bogus
+
+	s.setDefaults()
+
+	assert.False(t, s.snapshotsEnabled, "an unparsable interval must disable snapshots for the stage, never be fatal")
+	assert.Contains(t, buf.String(), "\"level\":\"error\"")
+	assert.Contains(t, buf.String(), "json_snapshot_interval")
+}
+
+func TestSnapshotIntervalValidation_SubFloorClamped(t *testing.T) {
+	buf := new(strings.Builder)
+	log.SetGlobalLogger(log.Output(buf))
+	defer log.SetGlobalLogger(log.Output(os.Stderr))
+
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 30 * time.Second}
+	tooShort := "1s"
+	s := newSnapshotTestStage(states)
+	s.JsonSnapshotInterval = &tooShort
+
+	s.setDefaults()
+
+	assert.True(t, s.snapshotsEnabled)
+	assert.Equal(t, MinSnapshotInterval, s.snapshotInterval)
+	assert.Contains(t, buf.String(), "\"level\":\"warn\"")
+}
+
+func TestSnapshotFetchTimeoutValidation_UnparsableFallsBackToInterval(t *testing.T) {
+	buf := new(strings.Builder)
+	log.SetGlobalLogger(log.Output(buf))
+	defer log.SetGlobalLogger(log.Output(os.Stderr))
+
+	states := &SharedStageStates{SnapshotsEnabled: true, SnapshotInterval: 12 * time.Second}
+	bogus := "nope"
+	s := newSnapshotTestStage(states)
+	s.JsonSnapshotFetchTimeout = &bogus
+
+	s.setDefaults()
+
+	// Fetch timeout falls back to the resolved interval; snapshots stay enabled (only the
+	// interval field's own unparsable case disables the stage, per UT-8).
+	assert.True(t, s.snapshotsEnabled)
+	assert.Equal(t, 12*time.Second, s.snapshotFetchTimeout)
+	assert.Contains(t, buf.String(), "\"level\":\"error\"")
 }

--- a/stage/stage_utils.go
+++ b/stage/stage_utils.go
@@ -90,6 +90,18 @@ func (s *Stage) MergeWith(other *Stage) *Stage {
 	if other.SaveJson != nil {
 		s.SaveJson = other.SaveJson
 	}
+	if other.SaveJsonSnapshots != nil {
+		s.SaveJsonSnapshots = other.SaveJsonSnapshots
+	}
+	if other.JsonSnapshotInterval != nil {
+		s.JsonSnapshotInterval = other.JsonSnapshotInterval
+	}
+	if other.JsonSnapshotMax != nil {
+		s.JsonSnapshotMax = other.JsonSnapshotMax
+	}
+	if other.JsonSnapshotFetchTimeout != nil {
+		s.JsonSnapshotFetchTimeout = other.JsonSnapshotFetchTimeout
+	}
 	if other.StreamCount != nil {
 		s.StreamCount = other.StreamCount
 	}
@@ -239,6 +251,7 @@ func (s *Stage) setDefaults() {
 		s.ColdRuns = intPtr(1)
 		s.WarmRuns = intPtr(0)
 	}
+	s.resolveSnapshotSettings()
 }
 
 func (s *Stage) propagateStates() {
@@ -296,6 +309,18 @@ func (s *Stage) propagateStates() {
 			}
 			if nextStage.SaveJson == nil {
 				nextStage.SaveJson = s.SaveJson
+			}
+			if nextStage.SaveJsonSnapshots == nil {
+				nextStage.SaveJsonSnapshots = s.SaveJsonSnapshots
+			}
+			if nextStage.JsonSnapshotInterval == nil {
+				nextStage.JsonSnapshotInterval = s.JsonSnapshotInterval
+			}
+			if nextStage.JsonSnapshotMax == nil {
+				nextStage.JsonSnapshotMax = s.JsonSnapshotMax
+			}
+			if nextStage.JsonSnapshotFetchTimeout == nil {
+				nextStage.JsonSnapshotFetchTimeout = s.JsonSnapshotFetchTimeout
 			}
 			nextStage.States = s.States
 			nextStage.Client = s.Client

--- a/stage/states.go
+++ b/stage/states.go
@@ -21,6 +21,18 @@ type SharedStageStates struct {
 	// OutputPath is where we store the logs, query results, query json files, query column metadata files, etc.
 	// It should be set by the --output/-o command-line argument. Once set there, its value gets propagated to all the stages.
 	OutputPath string
+	// SnapshotsEnabled is the run-wide default for periodic query JSON snapshot collection,
+	// set via the --snapshots command-line flag. Stages can override it with SaveJsonSnapshots.
+	// See stage/json_snapshot.go.
+	SnapshotsEnabled bool
+	// SnapshotInterval is the run-wide default snapshot polling interval, set via --snapshot-interval.
+	SnapshotInterval time.Duration
+	// SnapshotMax is the run-wide default snapshot retention cap per query, set via --snapshot-max.
+	// 0 means unlimited (only meaningful when explicitly set, since the flag's own default is non-zero).
+	SnapshotMax int
+	// SnapshotFetchTimeout is the run-wide default per-fetch timeout for snapshot requests, set via
+	// --snapshot-fetch-timeout. <= 0 means "use the polling interval".
+	SnapshotFetchTimeout time.Duration
 	// NewClient is called when the stage needs to create a new Presto client. This function is passed down to descendant stages by default.
 	NewClient utils.NewPrestoClientFn
 	// AbortAll is passed down to descendant stages by default and will be used to cancel the current context.


### PR DESCRIPTION
## Add `--snapshots`: periodic query-JSON time-series capture
  
  ### Summary
  Today pbench saves a single query JSON **after** a query finishes — a terminal snapshot.
  That's a photo; it can't answer time-based questions (when did throughput collapse,
  which stage stalled, is a query in a runaway state). This PR adds an opt-in flag that
  periodically captures `/v1/query/{id}` **while the query runs**, producing a time-series
  of query-JSON frames — a movie instead of a photo.
  
  ### What's new
  - New `pbench run` flags (all opt-in; **default off**):
    - `--snapshots` — master switch
    - `--snapshot-interval` (default `30s`, 5s floor)
    - `--snapshot-max` (default `20`; `0` = unlimited)
    - `--snapshot-fetch-timeout` (default = interval)
  - Equivalent inheritable per-stage JSON options (`save_json_snapshots`, …).
    Precedence: per-stage JSON > CLI flag > default.
  - Frames are written verbatim (raw Presto JSON, no schema change) to a sibling
    `<query>.snapshots/snapshot_<seq>_<epochMillis>.json` directory — one per query.
  
  ### Behavior & safety
  - **No regression:** with `--snapshots` off, behavior/output is byte-identical to today
    (no `.snapshots/` dir, no extra polling).
  - Diagnostic mode, not for timed baseline runs (polling adds coordinator load).
  - Non-overlapping polls; on stop the in-flight fetch is aborted (never delays query
    completion) and partial files are cleaned up.
  - Errors never fail the query; consecutive failures back off exponentially and the
    poller is never permanently disabled. Retention keeps the earliest frame + most recent.
  
  ### Testing
  - Unit + function tests (mock coordinator), 93.8% coverage on the new poller, `-race` clean.
  - Cluster-tested on a real ~10-min `EXCEEDED_TIME_LIMIT` query: regression pass (snapshots
    off → unchanged) and feature pass (20 frames captured, clean stop; the series shows CPU
    climbing while progress flatlines — the runaway-query signature the single terminal file misses).
  
  _Also includes a Go toolchain bump 1.26.4 → 1.26.5 to clear `govulncheck` GO-2026-5856
  (crypto/tls); verified 0 code-affecting vulnerabilities under 1.26.5._
